### PR TITLE
Fix zoxide configuration initialization order

### DIFF
--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -23,6 +23,14 @@ if status is-interactive
     # https://github.com/ajeetdsouza/zoxide
     zoxide init fish | source
 
+    # fzf integration
+    # https://github.com/junegunn/fzf#using-homebrew-or-linuxbrew
+    if command -v fzf >/dev/null
+        if test -f (brew --prefix)/opt/fzf/shell/key-bindings.fish
+            source (brew --prefix)/opt/fzf/shell/key-bindings.fish
+        end
+    end
+
     if test -e $HOME/.secrets/config.fish.local
         source $HOME/.secrets/config.fish.local
     end

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -123,3 +123,6 @@
 
 [url "https://"]
   insteadOf = git://
+[user]
+	name = Peter Yeh
+	email = peter.yeh@gmail.com

--- a/zsh/.config/zsh/colors.zsh
+++ b/zsh/.config/zsh/colors.zsh
@@ -14,5 +14,10 @@ ZSH_HIGHLIGHT_HIGHLIGHTERS=(main regexp)
 # ZSH_HIGHLIGHT_STYLES[default]='fg=#7EBDB3'
 # ZSH_HIGHLIGHT_STYLES[unknown-token]='fg=#F0776D'
 
-ZSH_HIGHLIGHT_REGEXP=('^[[:blank:][:space:]]*('${(j:|:)${(Qk)ABBR_REGULAR_USER_ABBREVIATIONS}}')$' fg=blue)
-ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]('${(j:|:)${(Qk)ABBR_GLOBAL_USER_ABBREVIATIONS}}')$' fg=magenta)
+# Only set regexp highlighting if abbreviation variables are available
+if [[ -n "${ABBR_REGULAR_USER_ABBREVIATIONS:-}" ]]; then
+    ZSH_HIGHLIGHT_REGEXP=('^[[:blank:][:space:]]*('${(j:|:)${(Qk)ABBR_REGULAR_USER_ABBREVIATIONS}}')$' fg=blue)
+fi
+if [[ -n "${ABBR_GLOBAL_USER_ABBREVIATIONS:-}" ]]; then
+    ZSH_HIGHLIGHT_REGEXP+=('[[:<:]]('${(j:|:)${(Qk)ABBR_GLOBAL_USER_ABBREVIATIONS}}')$' fg=magenta)
+fi

--- a/zsh/.config/zsh/plugins.zsh
+++ b/zsh/.config/zsh/plugins.zsh
@@ -25,8 +25,7 @@ fpath=(${ASDF_DATA_DIR:-$HOME/.asdf}/completions $fpath)
 # https://github.com/junegunn/fzf
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
-# https://github.com/ajeetdsouza/zoxide
-eval "$(zoxide init zsh)"
+# zoxide initialization moved to end of .zshrc for proper configuration
 
 # https://github.com/zsh-users/zsh-history-substring-search
 HISTORY_SUBSTRING_SEARCH_PREFIXED=1

--- a/zsh/.config/zsh/plugins.zsh
+++ b/zsh/.config/zsh/plugins.zsh
@@ -2,11 +2,14 @@
 
 [ -f "${XDG_DATA_HOME:-$HOME/.local/share}/zap/zap.zsh" ] && source "${XDG_DATA_HOME:-$HOME/.local/share}/zap/zap.zsh"
 
-plug "zsh-users/zsh-autosuggestions"
-plug "zap-zsh/supercharge"
-plug "zsh-users/zsh-syntax-highlighting"
-plug "zap-zsh/exa"
-plug "zsh-users/zsh-history-substring-search"
+# Only use plug function if it's available (Zap is loaded)
+if command -v plug >/dev/null 2>&1; then
+    plug "zsh-users/zsh-autosuggestions"
+    plug "zap-zsh/supercharge"
+    plug "zsh-users/zsh-syntax-highlighting"
+    plug "zap-zsh/exa"
+    plug "zsh-users/zsh-history-substring-search"
+fi
 
 # https://starship.rs
 if [ "$TERM_PROGRAM" != "Apple_Terminal" ]; then

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -21,7 +21,9 @@ export GPG_TTY=$(tty)
 . "$XDG_CONFIG_HOME/zsh/functions.zsh"
 . "$XDG_CONFIG_HOME/zsh/colors.zsh"
 . "$XDG_CONFIG_HOME/zsh/docker.sh"
-. "$HOME/.zshrc.local"
+if [[ -f "$HOME/.zshrc.local" ]]; then
+    . "$HOME/.zshrc.local"
+fi
 
 # Configure npm to use asdf's Node for global packages
 if command -v npm >/dev/null; then
@@ -48,6 +50,18 @@ setopt SHARE_HISTORY             # Share command history data
 if type brew &>/dev/null
 then
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+fi
+
+# fzf integration
+# https://github.com/junegunn/fzf#using-homebrew-or-linuxbrew
+if type fzf &>/dev/null; then
+  # Setup fzf key bindings and fuzzy completion
+  if [[ -f "$(brew --prefix)/opt/fzf/shell/key-bindings.zsh" ]]; then
+    source "$(brew --prefix)/opt/fzf/shell/key-bindings.zsh"
+  fi
+  if [[ -f "$(brew --prefix)/opt/fzf/shell/completion.zsh" ]]; then
+    source "$(brew --prefix)/opt/fzf/shell/completion.zsh"
+  fi
 fi
 
 # Docker CLI completions

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -92,3 +92,8 @@ if command -v gh >/dev/null 2>&1; then
 fi
 
 . "$HOME/.config/zsh/profiler.stop"
+
+# Initialize zoxide at the very end of shell configuration
+# https://github.com/ajeetdsouza/zoxide
+export _ZO_DOCTOR=0  # Disable zoxide doctor warnings
+eval "$(zoxide init zsh)"


### PR DESCRIPTION
This pull request enhances the shell configuration for both Zsh and Fish by improving plugin loading safety, adding fzf integration, and refining initialization logic for zoxide and user-specific settings. These changes make the shell environment more robust and user-friendly, with better conditional sourcing and improved support for abbreviations and completions.

**Shell plugin and integration improvements:**

* Added conditional loading for plugins in `zsh/.config/zsh/plugins.zsh` to ensure plugins are only loaded if the `plug` function is available, preventing errors when Zap is not loaded.
* Integrated fzf key bindings and completions for both Zsh (`zsh/.zshrc`) and Fish (`fish/.config/fish/config.fish`), with checks to ensure fzf is installed before sourcing related files. [[1]](diffhunk://#diff-aa540a91ec15311e6a566dd406c5999db0b6db04ad157b39e7f6babe2d727740R55-R66) [[2]](diffhunk://#diff-a97a9ea9888a87dacad227d522c51ca9a1b3b4be74499a68a228d64a3efdb47eR26-R33)

**Initialization and configuration changes:**

* Moved zoxide initialization to the end of `.zshrc` for proper configuration and disabled zoxide doctor warnings for a cleaner startup. [[1]](diffhunk://#diff-aa540a91ec15311e6a566dd406c5999db0b6db04ad157b39e7f6babe2d727740R95-R99) [[2]](diffhunk://#diff-dd111e451e732d06062517ea8a3996bcd3d0a333c059da2a5b5e4546c5514fdaL25-R28)
* Added conditional sourcing of a user-specific configuration file (`.zshrc.local`) in `.zshrc` to allow local overrides without errors if the file does not exist.

**Abbreviation and highlighting enhancements:**

* Updated `zsh/.config/zsh/colors.zsh` to conditionally set regexp highlighting only if abbreviation variables are available, improving robustness of syntax highlighting.

**Git configuration update:**

* Added user name and email information to `git/.gitconfig` for proper Git commit attribution.