### PR TITLE
Fix zoxide and add sync functionality

### DIFF
--- a/docs/setup/sync-with-upstream.md
+++ b/docs/setup/sync-with-upstream.md
@@ -1,0 +1,241 @@
+# Syncing Dotfiles with Upstream
+
+This guide explains how to sync your personal dotfiles with upstream changes from a template or base repository.
+
+## Overview
+
+The `sync-dotfiles.sh` script provides a safe way to merge upstream changes into your personal dotfiles repository while preserving your customizations.
+
+## Quick Start
+
+### 1. Set Up Upstream Remote
+
+First, add the upstream repository as a remote:
+
+```bash
+# Navigate to your dotfiles
+cdot
+
+# Add upstream remote (replace with your template repository)
+git remote add upstream https://github.com/template-user/dotfiles.git
+
+# Or use the sync script to set it up
+./scripts/sync-dotfiles.sh --upstream https://github.com/template-user/dotfiles.git
+```
+
+### 2. Sync with Upstream
+
+```bash
+# Preview changes without applying them
+dfsyncd
+
+# Sync with backup (recommended)
+dfsyncb
+
+# Or sync directly
+dfsync
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `dfsync` | Sync dotfiles with upstream repository |
+| `dfsyncb` | Sync with upstream and create backup |
+| `dfsyncd` | Preview sync changes without applying |
+
+## Script Options
+
+The sync script supports several options:
+
+```bash
+./scripts/sync-dotfiles.sh [OPTIONS]
+
+Options:
+  --upstream <url>     Set upstream repository URL
+  --dry-run           Show what would be done without making changes
+  --force             Force sync even with conflicts
+  --backup            Create backup before syncing
+  --help              Show help message
+```
+
+## Workflow
+
+The sync process follows these steps:
+
+1. **Prerequisites Check**: Verifies you're in a git repository and checks for uncommitted changes
+2. **Upstream Setup**: Configures or updates the upstream remote
+3. **Fetch Changes**: Downloads latest changes from upstream
+4. **Show Changes**: Displays what changes will be applied
+5. **Create Backup**: (Optional) Creates a timestamped backup
+6. **Merge Changes**: Attempts to merge upstream changes
+7. **Handle Conflicts**: Guides you through conflict resolution if needed
+8. **Update Symlinks**: Runs setup.sh to update symlinks
+
+## Safety Features
+
+### Automatic Backup
+
+When using `--backup` or `dfsyncb`, the script creates a timestamped backup:
+
+```bash
+# Backup location
+~/.dotfiles-backup-20240101-120000/
+
+# To restore from backup
+cp -r ~/.dotfiles-backup-20240101-120000/dotfiles/* ~/dotfiles/
+```
+
+### Conflict Detection
+
+The script detects potential issues:
+
+- Uncommitted changes (use `--force` to override)
+- Merge conflicts (manual resolution required)
+- Missing upstream remote (helpful error messages)
+
+### Dry Run Mode
+
+Preview changes before applying:
+
+```bash
+./scripts/sync-dotfiles.sh --dry-run
+```
+
+## Handling Conflicts
+
+If merge conflicts occur:
+
+1. **Resolve conflicts** in your editor
+2. **Stage resolved files**: `git add .`
+3. **Complete merge**: `git commit`
+4. **Or abort**: `git merge --abort`
+
+## Best Practices
+
+### Before Syncing
+
+1. **Commit your changes**: `git add . && git commit -m "Save my customizations"`
+2. **Create a backup**: Use `--backup` flag
+3. **Test in a branch**: Create a test branch first
+
+### After Syncing
+
+1. **Test your configuration**: `./scripts/validate-config.sh`
+2. **Reload your shell**: `src` (Zsh) or restart terminal
+3. **Check customizations**: Verify your `.local` files still work
+4. **Update if needed**: Modify any customizations that conflict
+
+## Example Workflow
+
+```bash
+# 1. Navigate to dotfiles
+cdot
+
+# 2. Commit any local changes
+git add .
+git commit -m "Save my customizations"
+
+# 3. Preview upstream changes
+dfsyncd
+
+# 4. Sync with backup
+dfsyncb
+
+# 5. Test configuration
+./scripts/validate-config.sh
+
+# 6. Reload shell
+src
+```
+
+## Troubleshooting
+
+### "No upstream remote configured"
+
+```bash
+# Add upstream remote
+./scripts/sync-dotfiles.sh --upstream https://github.com/user/dotfiles.git
+```
+
+### "You have uncommitted changes"
+
+```bash
+# Commit your changes first
+git add .
+git commit -m "Save changes"
+
+# Or force sync (not recommended)
+./scripts/sync-dotfiles.sh --force
+```
+
+### Merge conflicts
+
+```bash
+# Resolve conflicts manually
+git status
+# Edit conflicted files
+git add .
+git commit
+
+# Or abort the merge
+git merge --abort
+```
+
+### Symlink issues
+
+```bash
+# Re-run setup to fix symlinks
+./setup.sh
+```
+
+## Integration with Local Customizations
+
+The sync script works well with the `.local` file pattern:
+
+- **Personal configs**: `~/.gitconfig.local`, `~/.zshrc.local`
+- **Safe from updates**: Won't be overwritten during sync
+- **Automatic loading**: Loaded by main configuration files
+
+## Advanced Usage
+
+### Custom Upstream Branch
+
+```bash
+# Sync from a specific branch
+git fetch upstream feature-branch
+git merge upstream/feature-branch
+```
+
+### Selective Syncing
+
+```bash
+# Sync specific files only
+git checkout upstream/master -- path/to/file
+```
+
+### Multiple Upstreams
+
+```bash
+# Add multiple upstreams
+git remote add upstream1 https://github.com/user1/dotfiles.git
+git remote add upstream2 https://github.com/user2/dotfiles.git
+```
+
+## Security Considerations
+
+- **Verify upstream URLs**: Ensure you trust the upstream repository
+- **Review changes**: Always review what changes will be applied
+- **Backup regularly**: Create backups before major syncs
+- **Test changes**: Validate configuration after syncing
+
+## Contributing Back
+
+If you make improvements to the dotfiles:
+
+1. **Fork the upstream repository**
+2. **Create a feature branch**
+3. **Make your changes**
+4. **Submit a pull request**
+
+This helps improve the template for everyone!

--- a/fish/.config/fish/abbreviations.fish
+++ b/fish/.config/fish/abbreviations.fish
@@ -52,6 +52,9 @@ abbr -a -g bsv 'brew services'
 
 # config dirs
 abbr -a -g cdot 'cd $DOTFILES'
+abbr -a -g dfsync '$DOTFILES/scripts/sync-dotfiles.sh'
+abbr -a -g dfsyncb '$DOTFILES/scripts/sync-dotfiles.sh --backup'
+abbr -a -g dfsyncd '$DOTFILES/scripts/sync-dotfiles.sh --dry-run'
 abbr -a -g cdxc 'cd $XDG_CONFIG_HOME'
 abbr -a -g cdfi 'cd $XDG_CONFIG_HOME/fish'
 abbr -a -g cdnv 'cd $XDG_CONFIG_HOME/nvim'

--- a/scripts/sync-dotfiles.sh
+++ b/scripts/sync-dotfiles.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+#
+# Dotfiles Sync Script
+# Syncs local dotfiles with upstream repository changes
+#
+# Usage:
+#   ./scripts/sync-dotfiles.sh [options]
+#
+# Options:
+#   --upstream <url>     Set upstream repository URL
+#   --dry-run           Show what would be done without making changes
+#   --force              Force sync even with conflicts
+#   --backup             Create backup before syncing
+#   --help               Show this help message
+#
+# Examples:
+#   ./scripts/sync-dotfiles.sh --upstream https://github.com/user/dotfiles.git
+#   ./scripts/sync-dotfiles.sh --dry-run
+#   ./scripts/sync-dotfiles.sh --backup
+
+set -euo pipefail
+
+# Colors for output
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[0;34m'
+readonly NC='\033[0m' # No Color
+
+# Configuration
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly DOTFILES_DIR="$(dirname "$SCRIPT_DIR")"
+readonly BACKUP_DIR="$HOME/.dotfiles-backup-$(date +%Y%m%d-%H%M%S)"
+
+# Default values
+UPSTREAM_URL=""
+DRY_RUN=false
+FORCE=false
+BACKUP=false
+
+# Functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+show_help() {
+    cat << EOF
+Dotfiles Sync Script
+
+Syncs local dotfiles with upstream repository changes.
+
+USAGE:
+    $0 [OPTIONS]
+
+OPTIONS:
+    --upstream <url>     Set upstream repository URL
+    --dry-run           Show what would be done without making changes
+    --force             Force sync even with conflicts
+    --backup            Create backup before syncing
+    --help              Show this help message
+
+EXAMPLES:
+    $0 --upstream https://github.com/user/dotfiles.git
+    $0 --dry-run
+    $0 --backup
+
+WORKFLOW:
+    1. Fetches changes from upstream
+    2. Shows diff of changes
+    3. Creates backup (if --backup specified)
+    4. Merges upstream changes
+    5. Handles conflicts (if any)
+    6. Updates symlinks if needed
+
+NOTES:
+    - Run from the dotfiles directory
+    - Ensure you have committed or stashed local changes
+    - Backup is recommended for safety
+EOF
+}
+
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    # Check if we're in a git repository
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+        log_error "Not in a git repository. Please run from the dotfiles directory."
+        exit 1
+    fi
+    
+    # Check if we're in the dotfiles directory
+    if [[ ! -f "$DOTFILES_DIR/setup.sh" ]]; then
+        log_error "Not in dotfiles directory. Please run from the dotfiles root."
+        exit 1
+    fi
+    
+    # Check for uncommitted changes
+    if ! git diff-index --quiet HEAD --; then
+        log_warning "You have uncommitted changes."
+        if [[ "$FORCE" == false ]]; then
+            log_error "Please commit or stash your changes before syncing."
+            log_info "Use --force to override this check."
+            exit 1
+        fi
+    fi
+    
+    log_success "Prerequisites check passed"
+}
+
+setup_upstream() {
+    if [[ -n "$UPSTREAM_URL" ]]; then
+        log_info "Setting up upstream remote: $UPSTREAM_URL"
+        
+        if git remote get-url upstream > /dev/null 2>&1; then
+            log_info "Updating existing upstream remote"
+            git remote set-url upstream "$UPSTREAM_URL"
+        else
+            log_info "Adding new upstream remote"
+            git remote add upstream "$UPSTREAM_URL"
+        fi
+        
+        log_success "Upstream remote configured"
+    else
+        # Check if upstream already exists
+        if ! git remote get-url upstream > /dev/null 2>&1; then
+            log_error "No upstream remote configured."
+            log_info "Please specify upstream URL with --upstream <url>"
+            log_info "Example: $0 --upstream https://github.com/user/dotfiles.git"
+            exit 1
+        fi
+        
+        log_info "Using existing upstream remote: $(git remote get-url upstream)"
+    fi
+}
+
+fetch_upstream() {
+    log_info "Fetching changes from upstream..."
+    git fetch upstream
+    
+    # Get the current branch
+    local current_branch
+    current_branch=$(git branch --show-current)
+    
+    # Get upstream branch (usually master or main)
+    local upstream_branch
+    upstream_branch=$(git symbolic-ref refs/remotes/upstream/HEAD 2>/dev/null | sed 's@^refs/remotes/upstream/@@' || echo "master")
+    
+    log_info "Current branch: $current_branch"
+    log_info "Upstream branch: $upstream_branch"
+    
+    # Check if there are new commits
+    local commits_behind
+    commits_behind=$(git rev-list --count HEAD..upstream/$upstream_branch 2>/dev/null || echo "0")
+    
+    if [[ "$commits_behind" == "0" ]]; then
+        log_success "Already up to date with upstream"
+        return 0
+    fi
+    
+    log_info "Found $commits_behind new commits from upstream"
+    return 1
+}
+
+show_upstream_changes() {
+    local current_branch
+    current_branch=$(git branch --show-current)
+    
+    local upstream_branch
+    upstream_branch=$(git symbolic-ref refs/remotes/upstream/HEAD 2>/dev/null | sed 's@^refs/remotes/upstream/@@' || echo "master")
+    
+    log_info "Changes from upstream ($upstream_branch):"
+    echo
+    git log --oneline --graph HEAD..upstream/$upstream_branch
+    echo
+    
+    log_info "Detailed diff:"
+    git diff HEAD..upstream/$upstream_branch
+}
+
+create_backup() {
+    if [[ "$BACKUP" == true ]]; then
+        log_info "Creating backup in $BACKUP_DIR..."
+        mkdir -p "$BACKUP_DIR"
+        
+        # Copy the entire dotfiles directory
+        cp -r "$DOTFILES_DIR" "$BACKUP_DIR/"
+        
+        log_success "Backup created: $BACKUP_DIR"
+        log_info "To restore: cp -r $BACKUP_DIR/dotfiles/* $DOTFILES_DIR/"
+    fi
+}
+
+merge_upstream() {
+    local current_branch
+    current_branch=$(git branch --show-current)
+    
+    local upstream_branch
+    upstream_branch=$(git symbolic-ref refs/remotes/upstream/HEAD 2>/dev/null | sed 's@^refs/remotes/upstream/@@' || echo "master")
+    
+    log_info "Merging upstream changes..."
+    
+    if [[ "$DRY_RUN" == true ]]; then
+        log_info "[DRY RUN] Would merge upstream/$upstream_branch into $current_branch"
+        return 0
+    fi
+    
+    # Try to merge
+    if git merge upstream/$upstream_branch --no-edit; then
+        log_success "Successfully merged upstream changes"
+    else
+        log_warning "Merge conflicts detected"
+        log_info "Please resolve conflicts and run: git add . && git commit"
+        log_info "Or abort the merge with: git merge --abort"
+        return 1
+    fi
+}
+
+update_symlinks() {
+    log_info "Checking if symlinks need updating..."
+    
+    if [[ "$DRY_RUN" == true ]]; then
+        log_info "[DRY RUN] Would run setup.sh to update symlinks"
+        return 0
+    fi
+    
+    # Run setup.sh to update symlinks
+    log_info "Running setup.sh to update symlinks..."
+    if bash "$DOTFILES_DIR/setup.sh"; then
+        log_success "Symlinks updated successfully"
+    else
+        log_warning "Setup script had issues, but sync completed"
+    fi
+}
+
+cleanup() {
+    log_info "Sync completed successfully!"
+    
+    if [[ "$BACKUP" == true ]]; then
+        log_info "Backup available at: $BACKUP_DIR"
+    fi
+    
+    log_info "You may want to:"
+    log_info "  - Test your configuration: ./scripts/validate-config.sh"
+    log_info "  - Reload your shell: src (Zsh) or restart terminal"
+    log_info "  - Check for any local customizations that need updating"
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --upstream)
+            UPSTREAM_URL="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        --backup)
+            BACKUP=true
+            shift
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Main execution
+main() {
+    log_info "Starting dotfiles sync..."
+    
+    check_prerequisites
+    setup_upstream
+    
+    if fetch_upstream; then
+        log_success "No sync needed - already up to date"
+        exit 0
+    fi
+    
+    show_upstream_changes
+    
+    if [[ "$DRY_RUN" == true ]]; then
+        log_info "[DRY RUN] Would create backup, merge changes, and update symlinks"
+        exit 0
+    fi
+    
+    create_backup
+    
+    if merge_upstream; then
+        update_symlinks
+        cleanup
+    else
+        log_error "Sync failed due to merge conflicts"
+        log_info "Please resolve conflicts and complete the merge manually"
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"

--- a/shared/abbreviations.yaml
+++ b/shared/abbreviations.yaml
@@ -142,6 +142,18 @@ config_dirs:
   cdot:
     command: "cd $DOTFILES"
     description: "Navigate to dotfiles repository"
+  # Sync dotfiles with upstream repository
+  dfsync:
+    command: "$DOTFILES/scripts/sync-dotfiles.sh"
+    description: "Sync dotfiles with upstream repository"
+  # Sync dotfiles with backup
+  dfsyncb:
+    command: "$DOTFILES/scripts/sync-dotfiles.sh --backup"
+    description: "Sync dotfiles with upstream and create backup"
+  # Dry run sync to preview changes
+  dfsyncd:
+    command: "$DOTFILES/scripts/sync-dotfiles.sh --dry-run"
+    description: "Preview dotfiles sync changes without applying"
   # Navigate to XDG config directory - central location for app configurations
   cdxc:
     command: "cd $XDG_CONFIG_HOME"

--- a/zsh/.config/zsh-abbr/abbreviations.zsh
+++ b/zsh/.config/zsh-abbr/abbreviations.zsh
@@ -55,6 +55,9 @@ abbr "bsv"="brew services"
 
 # config dirs
 abbr "cdot"="cd ${DOTFILES}"
+abbr "dfsync"="${DOTFILES}/scripts/sync-dotfiles.sh"
+abbr "dfsyncb"="${DOTFILES}/scripts/sync-dotfiles.sh --backup"
+abbr "dfsyncd"="${DOTFILES}/scripts/sync-dotfiles.sh --dry-run"
 abbr "cdxc"="cd ${XDG_CONFIG_HOME}"
 abbr "cdfi"="cd ${XDG_CONFIG_HOME}/fish"
 abbr "cdnv"="cd ${XDG_CONFIG_HOME}/nvim"


### PR DESCRIPTION
This pull request introduces a new workflow for safely syncing personal dotfiles with changes from an upstream template repository. The main addition is a robust `sync-dotfiles.sh` script, along with updated shell abbreviations and comprehensive documentation to guide users through the sync process.

**Dotfiles sync workflow and tooling**

* Added `scripts/sync-dotfiles.sh`, a Bash script that automates syncing local dotfiles with an upstream repository, including safety checks, backup creation, dry-run mode, and conflict handling.
* Created `docs/setup/sync-with-upstream.md`, a detailed guide explaining how to use the sync script, recommended workflows, troubleshooting, and best practices for integrating upstream changes while preserving local customizations.

**Shell abbreviations for sync commands**

* Added new abbreviations (`dfsync`, `dfsyncb`, `dfsyncd`) to Fish (`fish/.config/fish/abbreviations.fish`), Zsh (`zsh/.config/zsh-abbr/abbreviations.zsh`), and shared YAML (`shared/abbreviations.yaml`) for quickly running the sync script, with options for backup and dry-run modes. [[1]](diffhunk://#diff-2f2ae018e2d4a1b8dc24f6ade6f91317edfd8fa3e34fd574e0ff420ffcc47b4bR55-R57) [[2]](diffhunk://#diff-5b1c0116a037fe738f49ade7600498e32a260763065be827a0bca9ca4a4cb1b4R58-R60) [[3]](diffhunk://#diff-ae05a9a1e01aeec2bb52c170bd05cd6ec1bd5f063d758ead74f2e8c6b558ef70R145-R156)