### PR TITLE
feat: update fzf to use fd instead of rg for file searching

### DIFF
--- a/shared/environment.fish
+++ b/shared/environment.fish
@@ -34,7 +34,7 @@ set -gx SSH_AUTH_SOCK "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t
 set -gx PKB_PATH "$HOME/personal-knowledge-base"
 
 # FZF configuration
-set -gx FZF_DEFAULT_COMMAND 'rg --files --hidden --follow --no-ignore-vcs'
+set -gx FZF_DEFAULT_COMMAND 'fd --type f --hidden --follow --exclude .git'
 set -gx FZF_DEFAULT_OPTS '--height 75% --layout=reverse --border'
 set -gx FZF_CTRL_T_COMMAND $FZF_DEFAULT_COMMAND
 set -gx FZF_ALT_C_COMMAND 'fd --type d . --color=never'

--- a/shared/environment.sh
+++ b/shared/environment.sh
@@ -39,7 +39,7 @@ export SSH_AUTH_SOCK="${HOME}/Library/Group Containers/2BUA8C4S2C.com.1password/
 export PKB_PATH="${HOME}/personal-knowledge-base"
 
 # FZF configuration
-export FZF_DEFAULT_COMMAND="rg --files --hidden --follow --no-ignore-vcs"
+export FZF_DEFAULT_COMMAND="fd --type f --hidden --follow --exclude .git"
 export FZF_DEFAULT_OPTS="--height 75% --layout=reverse --border"
 export FZF_CTRL_T_COMMAND="${FZF_DEFAULT_COMMAND}"
 export FZF_ALT_C_COMMAND="fd --type d . --color=never"


### PR DESCRIPTION
## Summary

This PR updates the fzf configuration to use `fd` instead of `rg` for file searching operations, providing faster and more consistent file finding across the development environment.

## Changes Made

- **FZF_DEFAULT_COMMAND**: Changed from `rg --files --hidden --follow --no-ignore-vcs` to `fd --type f --hidden --follow --exclude .git`
- **FZF_CTRL_T_COMMAND**: Now uses the same `fd` command as the default command
- **FZF_ALT_C_COMMAND**: Already using `fd` for directory navigation (unchanged)
- Applied to both Zsh and Fish shell configurations via shared environment files

## Benefits

- **Performance**: `fd` is generally faster than `rg` for file finding operations
- **Consistency**: All fzf file operations now use the same tool (`fd`)
- **Better defaults**: `fd` has sensible defaults and respects `.gitignore` files automatically
- **Maintainability**: Single tool for all file operations reduces complexity

## Testing

- [x] Verified `fd` is installed via Homebrew
- [x] Updated both shell configurations (Zsh and Fish)
- [x] Maintained existing directory navigation functionality

## Files Changed

- `shared/environment.sh` - Zsh environment configuration
- `shared/environment.fish` - Fish environment configuration