### PR TITLE
fix(shared): detect HOMEBREW_PREFIX before use

### DIFF
--- a/shared/environment.sh
+++ b/shared/environment.sh
@@ -18,6 +18,15 @@ export MANPAGER="less -X" # Don't clear the screen after quitting a manual page
 # Homebrew configuration
 export HOMEBREW_CASK_OPTS="--appdir=/Applications"
 
+# Detect HOMEBREW_PREFIX if not already set (Apple Silicon vs Intel)
+if [[ -z "${HOMEBREW_PREFIX}" ]]; then
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    export HOMEBREW_PREFIX="/opt/homebrew"
+  else
+    export HOMEBREW_PREFIX="/usr/local"
+  fi
+fi
+
 # Development configuration
 export SOURCE_ANNOTATION_DIRECTORIES="spec"
 export RUBY_CONFIGURE_OPTS="--with-opt-dir=${HOMEBREW_PREFIX}/opt/openssl:${HOMEBREW_PREFIX}/opt/readline:${HOMEBREW_PREFIX}/opt/libyaml:${HOMEBREW_PREFIX}/opt/gdbm"


### PR DESCRIPTION
## Summary
- Add HOMEBREW_PREFIX detection in shared/environment.sh before it's used by RUBY_CONFIGURE_OPTS
- Supports both Apple Silicon (/opt/homebrew) and Intel (/usr/local) Macs
- Only sets if not already defined, preserving any existing value

## Test plan
- [ ] Source environment.sh on Apple Silicon Mac
- [ ] Verify HOMEBREW_PREFIX is /opt/homebrew
- [ ] Verify RUBY_CONFIGURE_OPTS contains correct paths