### PR TITLE
fix(fish): add missing end statement in fzf-git block

### DIFF
--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -27,7 +27,8 @@ if status is-interactive
     # Load fzf-git.sh for enhanced git operations with fuzzy finding
     if test -f $DOTFILES/bin/fzf-git.sh
         source $DOTFILES/bin/fzf-git.sh
-        
+    end
+
     # fzf integration
     # https://github.com/junegunn/fzf#using-homebrew-or-linuxbrew
     if command -v fzf >/dev/null


### PR DESCRIPTION
## Summary
- Add missing `end` statement after fzf-git.sh sourcing block
- Fixes incorrect nesting with subsequent fzf integration block

## Test plan
- [ ] Run `fish -n config.fish` to validate syntax
- [ ] Source config in Fish shell