### PR TITLE
fix(pre-commit): correct run-tests script path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,9 +33,9 @@ repos:
       # Critical scripts functionality test
       - id: critical-scripts-test
         name: Critical Scripts Test
-        entry: bash -c './bin/.local/bin/run-tests --fast shell-syntax | grep -q "All tests passed" && echo "✓ run-tests working correctly"'
+        entry: bash -c './scripts/run-tests --fast shell-syntax | grep -q "All tests passed" && echo "✓ run-tests working correctly"'
         language: system
-        files: ^bin/\.local/bin/run-tests$
+        files: ^scripts/run-tests$
         pass_filenames: false
 
       # Markdown linting - disabled for commit speed


### PR DESCRIPTION
## Summary
- Fix path from `./bin/.local/bin/run-tests` to `./scripts/run-tests`
- Update file pattern to match actual script location

## Test plan
- [ ] Run `pre-commit run critical-scripts-test --all-files`