### PR TITLE
chore(gitignore): add Claude Code runtime files and backup patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,18 @@ vim/bundle
 # Scratchpads for temporary files, notes, and debugging
 scratchpads/
 *.rej
+
+# Claude Code runtime files (machine-specific, not config)
+claude/.claude/debug/
+claude/.claude/file-history/
+claude/.claude/history.jsonl
+claude/.claude/plugins/
+claude/.claude/projects/
+claude/.claude/settings.local.json
+claude/.claude/shell-snapshots/
+claude/.claude/stats-cache.json
+claude/.claude/statsig/
+claude/.claude/todos/
+
+# Backup files
+*.bak


### PR DESCRIPTION
## Summary
- Add Claude Code machine-specific runtime directories to .gitignore
- Add `*.bak` pattern for backup files
- Prevents merge conflicts across machines from user-specific data

## Files ignored
- `claude/.claude/debug/` - debug logs
- `claude/.claude/file-history/` - file edit history
- `claude/.claude/history.jsonl` - conversation history
- `claude/.claude/plugins/` - installed plugins
- `claude/.claude/projects/` - project data
- `claude/.claude/settings.local.json` - local settings
- `claude/.claude/shell-snapshots/` - shell state snapshots
- `claude/.claude/stats-cache.json` - usage stats
- `claude/.claude/statsig/` - feature flags
- `claude/.claude/todos/` - todo lists

## Test plan
- [ ] Verify `git status` no longer shows these files as untracked