### PR TITLE
fix(zsh): use portable path for Docker completions

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -72,7 +72,9 @@ if type fzf &>/dev/null; then
 fi
 
 # Docker CLI completions
-fpath=(/Users/joshukraine/.docker/completions $fpath)
+if [[ -d "${HOME}/.docker/completions" ]]; then
+  fpath=("${HOME}/.docker/completions" $fpath)
+fi
 
 # Load and initialise completion system with caching for performance
 autoload -Uz compinit


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/joshukraine/` path with `${HOME}` for portability
- Add conditional check to only add Docker completions to fpath if directory exists

## Test plan
- [ ] Source zsh config on machine with Docker installed
- [ ] Source zsh config on machine without Docker installed