### PR TITLE
feat(scripts): add single bootstrap script for fresh Mac setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,109 +96,52 @@ All of the above and more are installed with my fork of [Laptop][joshuas-laptop]
 
 ## 🌟 New Mac Bootstrap
 
-This is what I would do if I bought a new Mac computer today. The steps below assume you have already completed the basics:
+This is what I would do if I bought a new Mac computer today. A single bootstrap script handles everything — from Xcode CLI tools and Homebrew to language runtimes and shell setup.
+
+### Prerequisites
 
 - Log in to iCloud
 - Check for software updates
-- [Install Xcode Command Line Tools][install-clt]
 
-### 💻 1. Run my fork of thoughtbot’s Laptop
-
-&#9657; **[github.com/joshukraine/laptop][joshuas-laptop]**
-
-Download the `mac` script:
+### 🚀 One-liner
 
 ```sh
-curl --remote-name https://raw.githubusercontent.com/joshukraine/laptop/main/mac
+bash <(curl -fsSL https://raw.githubusercontent.com/pyeh/dotfiles/master/scripts/bootstrap.sh)
 ```
 
-Download `.local.laptop` for additional customizations:
+The bootstrap script runs the following phases automatically:
+
+1. Install Xcode Command Line Tools
+2. Install Rosetta 2 (Apple Silicon only)
+3. Install Homebrew + minimal formulae (git, stow, coreutils, etc.)
+4. Clone the dotfiles repo to `~/dotfiles`
+5. Run `setup.sh` (stow symlinks, hostname, directories, tmux)
+6. Install asdf + language runtimes (Ruby, Node.js, Python, Lua)
+7. Install gems and npm packages from `~/.default-gems` / `~/.default-npm-packages`
+8. Run `brew bundle install` (full Brewfile — this takes a while)
+9. Configure Zsh as default shell + install Zap plugin manager
+
+### Options
 
 ```sh
-curl --remote-name https://raw.githubusercontent.com/joshukraine/dotfiles/master/laptop/.laptop.local
+# Preview all phases without making changes
+./scripts/bootstrap.sh --dry-run
+
+# Skip the lengthy Brewfile install for faster re-runs
+./scripts/bootstrap.sh --skip-brew-bundle
+
+# Show usage
+./scripts/bootstrap.sh --help
 ```
 
-Review both scripts before proceeding:
+> [!NOTE]
+> The script is idempotent — safe to run multiple times. Each phase checks
+> whether its work has already been done and skips accordingly.
 
-```sh
-less mac
-```
-
-```sh
-less .laptop.local
-```
-
-Execute the `mac` script:
-
-```sh
-sh mac 2>&1 | tee ~/laptop.log
-```
-
-I’ve made the following changes to my fork of Laptop:
-
-- Install asdf via git instead of Homebrew
-- Comment out Heroku-related code
-- Comment out unused Homebrew taps and formulae
-
-It is worth noting that the Laptop script (`mac`) is idempotent and can be safely run multiple times to ensure a consistent baseline configuration.
-
-### ⚠️ 2. Check for Stow conflicts
-
-The dotfiles `setup.sh` script uses [GNU Stow][gnu-stow] to symlink all the config files to your `$HOME` directory. If you already have an identically-named file/directory in `$HOME` (e.g. `~/.zshrc` leftover from installing Laptop), this will cause a conflict, and Stow will (rightly) abort with an error.
-
-The setup script will try to detect and backup these files ahead of Stow, but it’s still a good idea to check your `$HOME` directory as well as `$HOME/.config` and `$HOME/.local/bin`.
-
-### 📍 3. Clone and setup the dotfiles
-
-Clone
-
-```sh
-git clone https://github.com/joshukraine/dotfiles.git ~/dotfiles
-```
-
-Read and preview
-
-```sh
-less ~/dotfiles/setup.sh
-~/dotfiles/setup.sh --help
-~/dotfiles/setup.sh --dry-run  # Preview changes without applying them
-```
-
-Setup
-
-```sh
-~/dotfiles/setup.sh
-```
-
-If you do encounter Stow conflicts, resolve these and run setup again. The script is idempotent, so you can run it multiple times safely.
-
-### ⚡️ 4. Install Zap
-
-[Zap][zap] describes itself as a _“minimal zsh plugin manager that does what you expect.”_
-
-&#9657; **[zapzsh.com][zap]**
-
-> [!IMPORTANT]
-> After copying/pasting the install command for Zap, be sure to add the `--keep` flag to prevent Zap from replacing you existing `.zshrc` file.
-
-### 🍺 5. Install remaining Homebrew packages
-
-Review the included `Brewfile` and make desired adjustments.
-
-```sh
-less ~/Brewfile
-```
-
-Install the bundle.
-
-```sh
-brew bundle install
-```
-
-### 🛠️ 6. Complete post-install tasks
+### 🛠️ Post-install tasks
 
 - [ ] Launch LazyVim (`nvim`) and run [`:checkhealth`][checkhealth]. Resolve errors and warnings. Plugins should install automatically on first launch.
-- [ ] Add personal data as needed to `*.local` files such as `~/.gitconfig.local`, `~/.laptop.local`, `~/dotfiles/local/config.fish.local`.
+- [ ] Create `~/.gitconfig.local` with your name and email
 - [ ] (Optional) Set up [1Password CLI][1p-cli-start] for managing secrets.
 - [ ] (Optional) Set up [1Password SSH key management][1p-cli-ssh].
 - [ ] If using Fish, customize your setup by running the `fish_config` command.

--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -7,12 +7,12 @@ tap "teamookla/speedtest"
 # Homebrew
 # https://github.com/Homebrew/brew/
 
-brew "advancecomp"
+# brew "advancecomp"              # not needed — compression optimizer
 brew "openssl@3"
 brew "libyaml"
 brew "readline"
 brew "ansible"
-brew "asciidoctor"
+# brew "asciidoctor"              # not needed — AsciiDoc converter
 brew "asdf"
 brew "awscli"
 brew "bash"
@@ -29,17 +29,17 @@ brew "docutils"
 brew "dos2unix"
 brew "eza"
 brew "fd"
-brew "ffmpegthumbnailer"
+# brew "ffmpegthumbnailer"        # not needed — video thumbnails
 brew "gcc"
 brew "fastfetch"
 brew "fish"
-brew "flyctl"
-brew "fontforge"
-brew "fonttools"
+# brew "flyctl"                   # not needed — Fly.io deployment CLI
+# brew "fontforge"                # not needed — font editor
+# brew "fonttools"                # not needed — font manipulation
 brew "fzf"
 brew "gh"
 brew "ghostscript"
-brew "gifsicle"
+# brew "gifsicle"                 # not needed — GIF manipulation
 brew "git"
 brew "git-quick-stats"
 brew "gnu-sed"
@@ -50,36 +50,36 @@ brew "pkgconf"
 brew "highlight"
 brew "htop"
 brew "httpie"
-brew "hugo"
+# brew "hugo"                     # not needed — static site generator
 brew "imagemagick"
-brew "jhead"
+# brew "jhead"                    # not needed — JPEG header editing
 brew "jq"
 brew "lazydocker"
 brew "lazygit"
 brew "less"
 brew "libpq"
 brew "libtermkey"
-brew "lynx"
+# brew "lynx"                     # not needed — text web browser
 brew "markdownlint-cli2"
 brew "mas"
 brew "media-info"
 brew "memcached"
 brew "most"
 brew "neovim"
-brew "node"
+# brew "node"                     # not needed — managed by asdf
 brew "onefetch"
 brew "ossp-uuid"
 brew "tmux"
-brew "overmind"
+# brew "overmind"                 # not needed — Procfile manager (Rails)
 brew "pandoc"
 brew "perl"
 brew "pgcli"
-brew "php"
+# brew "php"                      # not needed — web scripting language
 brew "pillow"
 brew "pinentry-mac"
 brew "poppler"
 brew "postgresql@17", restart_service: :changed
-brew "prettier"
+# brew "prettier"                 # not needed — JS/web formatter
 brew "pstree"
 brew "redis"
 brew "ripgrep"
@@ -100,29 +100,30 @@ brew "unar"
 brew "universal-ctags"
 brew "urlview"
 brew "vips"
-brew "w3m"
+# brew "w3m"                      # not needed — text web browser
 brew "wget"
-brew "wordnet"
+# brew "wordnet"                  # not needed — lexical database
 brew "yamllint"
-brew "yarn"
+# brew "yarn"                     # not needed — JS package manager
 brew "yq"
 brew "zlib"
 brew "zoxide"
 brew "zsh"
 brew "olets/tap/zsh-abbr"
-brew "stripe/stripe-cli/stripe"
+# brew "stripe/stripe-cli/stripe" # not needed — payment processing CLI
 brew "teamookla/speedtest/speedtest"
+brew "uv"
 
 # homebrew-cask
 # https://github.com/Homebrew/homebrew-cask
 
 # cask "1password-cli"
-cask "alfred"
-cask "bartender"
-cask "brave-browser"
-cask "carbon-copy-cloner"
-cask "cleanmymac"
-cask "firefox"
+# cask "alfred"                   # disabled
+# cask "bartender"                # disabled
+# cask "brave-browser"            # disabled
+# cask "carbon-copy-cloner"       # disabled
+# cask "cleanmymac"               # disabled
+# cask "firefox"                  # disabled
 cask "font-cascadia-code"
 cask "font-cascadia-code-nf"
 cask "font-fira-code"
@@ -139,32 +140,36 @@ cask "font-source-code-pro"
 cask "font-symbols-only-nerd-font"
 cask "ghostty"
 cask "google-drive"
-cask "grammarly-desktop"
-cask "hazel"
+# cask "grammarly-desktop"        # disabled
+# cask "hazel"                    # disabled
 cask "istat-menus"
-cask "kitty"
-cask "loom"
-cask "ngrok"
-cask "notion"
-cask "obsidian"
-cask "postico"
-cask "qxmledit"
-cask "screenflick"
-cask "signal"
-cask "tableplus"
-cask "telegram"
-cask "todoist-app"
-cask "viber"
-cask "whatsapp"
+cask "iterm2"
+# cask "kitty"                    # not needed — using ghostty
+# cask "loom"                     # not needed — screen recording
+# cask "ngrok"                    # disabled
+# cask "notion"                   # disabled
+# cask "obsidian"                 # disabled
+# cask "postico"                  # not needed — PostgreSQL GUI
+# cask "qxmledit"                 # not needed — XML editor
+# cask "screenflick"              # not needed — screen recording
+# cask "signal"                   # disabled
+# cask "tableplus"                # disabled
+# cask "telegram"                 # disabled
+# cask "todoist-app"              # disabled
+# cask "viber"                    # disabled
+# cask "whatsapp"                 # disabled
+cask "tailscale"
+cask "visual-studio-code"
+cask "zoom"
 
-mas "1Password for Safari", id: 1569813296
-mas "e-Sword X", id: 968437868
-mas "Keynote", id: 409183694
-mas "Logic Pro", id: 634148309
-mas "Marked 2", id: 890031187
-mas "Numbers", id: 409203825
-mas "Pages", id: 409201541
-mas "The Unarchiver", id: 425424353
-mas "Toggl Track", id: 1291898086
+# mas "1Password for Safari", id: 1569813296  # disabled
+# mas "e-Sword X", id: 968437868              # disabled
+# mas "Keynote", id: 409183694                # disabled
+# mas "Logic Pro", id: 634148309              # disabled
+# mas "Marked 2", id: 890031187              # disabled
+# mas "Numbers", id: 409203825               # disabled
+# mas "Pages", id: 409201541                 # disabled
+# mas "The Unarchiver", id: 425424353        # disabled
+# mas "Toggl Track", id: 1291898086          # disabled
 
 # vim: set filetype=ruby:

--- a/docs/setup/installation-guide.md
+++ b/docs/setup/installation-guide.md
@@ -13,22 +13,41 @@ This guide provides a complete, step-by-step walkthrough for installing the dotf
 
 ## 🛡️ Pre-Installation Checklist
 
-Before running the setup script, complete these essential steps:
+Before running the bootstrap script, complete these essential steps:
 
 ### ✅ 1. System Preparation
 
 - [ ] **Update macOS** - Ensure you're running the latest version
-- [ ] **Install Xcode Command Line Tools**:
-
-  ```bash
-  xcode-select --install
-  ```
-
 - [ ] **Complete initial macOS setup** (Apple ID, user account, etc.)
+- [ ] **Log in to iCloud**
 
-### ✅ 2. Required Software Installation
+### 🚀 2. Run the Bootstrap Script
 
-The setup script requires these components to be installed first:
+The bootstrap script handles everything automatically — Xcode CLI tools,
+Homebrew, dotfiles, language runtimes, and shell setup:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/pyeh/dotfiles/master/scripts/bootstrap.sh)
+```
+
+Preview what the script will do first:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/pyeh/dotfiles/master/scripts/bootstrap.sh) --dry-run
+```
+
+The bootstrap script is idempotent and can be run multiple times safely. See the
+[README](../../README.md#-new-mac-bootstrap) for the full list of phases and options.
+
+### Alternative: Manual Setup
+
+If you prefer manual control, you can install prerequisites individually:
+
+#### Install Xcode Command Line Tools
+
+```bash
+xcode-select --install
+```
 
 #### Install Homebrew
 
@@ -42,23 +61,6 @@ Follow the post-installation instructions to add Homebrew to your PATH.
 
 ```bash
 brew install stow
-```
-
-#### Optional: Run the Laptop Script
-
-For a complete development environment, consider running the [laptop script](https://github.com/joshukraine/laptop) first:
-
-```bash
-# Download and review the script
-curl --remote-name https://raw.githubusercontent.com/joshukraine/laptop/main/mac
-curl --remote-name https://raw.githubusercontent.com/joshukraine/dotfiles/master/laptop/.laptop.local
-
-# Review both scripts
-less mac
-less .laptop.local
-
-# Execute (this installs many development tools)
-sh mac 2>&1 | tee ~/laptop.log
 ```
 
 ## 🖥️ System Requirements

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+
+set -e
+
+################################################################################
+# bootstrap.sh
+#
+# Single bootstrap script to set up a fresh Mac from zero. Installs
+# prerequisites, clones the dotfiles repo, runs setup.sh, installs language
+# runtimes, and configures the default shell.
+#
+# Usage:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/pyeh/dotfiles/master/scripts/bootstrap.sh)
+#
+# Or after cloning:
+#   ./scripts/bootstrap.sh [OPTIONS]
+#
+# Options:
+#   --dry-run            Show what would be done without making changes
+#   --skip-brew-bundle   Skip the full Brewfile install (Phase 9)
+#   --help               Show this help message
+################################################################################
+
+# ---------------------------------------------------------------------------
+# Phase 0: Preflight
+# ---------------------------------------------------------------------------
+
+DOTFILES_REPO="https://github.com/pyeh/dotfiles.git"
+DOTFILES_DIR="${HOME}/dotfiles"
+DOTFILES_BRANCH="master"
+
+DRY_RUN=false
+SKIP_BREW_BUNDLE=false
+
+# Logging helpers (mirrors setup.sh patterns)
+bootstrap_echo() {
+  local fmt="$1"
+  shift
+  # shellcheck disable=SC2059
+  printf "\\n[BOOTSTRAP] ${fmt}\\n" "$@"
+}
+
+bootstrap_info() {
+  local fmt="$1"
+  shift
+  # shellcheck disable=SC2059
+  printf "[INFO] ${fmt}\\n" "$@"
+}
+
+bootstrap_warn() {
+  local fmt="$1"
+  shift
+  # shellcheck disable=SC2059
+  printf "[WARN] ${fmt}\\n" "$@" >&2
+}
+
+bootstrap_error() {
+  local fmt="$1"
+  shift
+  # shellcheck disable=SC2059
+  printf "[ERROR] ${fmt}\\n" "$@" >&2
+}
+
+run_cmd() {
+  local cmd="$1"
+  local description="${2:-}"
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_info "[DRY RUN] Would run: %s" "${cmd}"
+    if [[ -n "${description}" ]]; then
+      bootstrap_info "  Purpose: %s" "${description}"
+    fi
+  else
+    bootstrap_info "Running: %s" "${cmd}"
+    eval "${cmd}"
+  fi
+}
+
+show_help() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Bootstrap a fresh Mac from zero. Installs prerequisites, clones dotfiles,
+runs setup.sh, installs language runtimes, and configures the default shell.
+
+Options:
+  --dry-run            Show what would be done without making changes
+  --skip-brew-bundle   Skip the full Brewfile install (fastest re-run)
+  --help               Show this help message
+
+Examples:
+  bash <(curl -fsSL https://raw.githubusercontent.com/pyeh/dotfiles/master/scripts/bootstrap.sh)
+  $0                      # Full bootstrap
+  $0 --dry-run            # Preview all phases
+  $0 --skip-brew-bundle   # Skip lengthy Brewfile install
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --skip-brew-bundle)
+        SKIP_BREW_BUNDLE=true
+        shift
+        ;;
+      --help)
+        show_help
+        exit 0
+        ;;
+      *)
+        bootstrap_error "Unknown option: %s" "$1"
+        show_help
+        exit 1
+        ;;
+    esac
+  done
+}
+
+preflight() {
+  bootstrap_echo "Phase 0: Preflight checks"
+
+  local osname
+  osname="$(uname)"
+  if [[ "${osname}" != "Darwin" ]]; then
+    bootstrap_error "This script only supports macOS. Current OS: %s" "${osname}"
+    exit 1
+  fi
+  bootstrap_info "macOS detected"
+
+  local arch
+  arch="$(uname -m)"
+  if [[ "${arch}" == "arm64" ]]; then
+    HOMEBREW_PREFIX="/opt/homebrew"
+    bootstrap_info "Apple Silicon detected — HOMEBREW_PREFIX=%s" "${HOMEBREW_PREFIX}"
+  else
+    HOMEBREW_PREFIX="/usr/local"
+    bootstrap_info "Intel Mac detected — HOMEBREW_PREFIX=%s" "${HOMEBREW_PREFIX}"
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_echo "DRY RUN MODE — no changes will be made"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1: Xcode Command Line Tools
+# ---------------------------------------------------------------------------
+
+install_xcode_cli_tools() {
+  bootstrap_echo "Phase 1: Xcode Command Line Tools"
+
+  if xcode-select -p &>/dev/null; then
+    bootstrap_info "Xcode CLI tools already installed"
+    return
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_info "[DRY RUN] Would install Xcode CLI tools"
+    return
+  fi
+
+  bootstrap_info "Installing Xcode Command Line Tools..."
+  xcode-select --install
+
+  bootstrap_info "Waiting for Xcode CLI tools installation to complete..."
+  until xcode-select -p &>/dev/null; do
+    sleep 5
+  done
+  bootstrap_info "Xcode CLI tools installed"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: Rosetta 2 (Apple Silicon only)
+# ---------------------------------------------------------------------------
+
+install_rosetta() {
+  bootstrap_echo "Phase 2: Rosetta 2"
+
+  if [[ "$(uname -m)" != "arm64" ]]; then
+    bootstrap_info "Not Apple Silicon — skipping Rosetta"
+    return
+  fi
+
+  if pkgutil --pkg-info=com.apple.pkg.RosettaUpdateAuto &>/dev/null; then
+    bootstrap_info "Rosetta 2 already installed"
+    return
+  fi
+
+  run_cmd "softwareupdate --install-rosetta --agree-to-license" "Install Rosetta 2"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: Homebrew + Minimal Formulae
+# ---------------------------------------------------------------------------
+
+install_homebrew() {
+  bootstrap_echo "Phase 3: Homebrew + minimal formulae"
+
+  if command -v "${HOMEBREW_PREFIX}/bin/brew" &>/dev/null; then
+    bootstrap_info "Homebrew already installed"
+  else
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would install Homebrew"
+    else
+      bootstrap_info "Installing Homebrew..."
+      NONINTERACTIVE=1 /bin/bash -c \
+        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+  fi
+
+  # Ensure brew is on PATH for this session
+  if [[ "${DRY_RUN}" == "false" ]]; then
+    eval "$("${HOMEBREW_PREFIX}/bin/brew" shellenv)"
+  fi
+
+  # Minimal formulae needed for subsequent phases
+  local minimal_formulae=(git stow coreutils openssl@3 libyaml readline zsh)
+
+  bootstrap_info "Installing minimal formulae: %s" "${minimal_formulae[*]}"
+  for formula in "${minimal_formulae[@]}"; do
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would install: %s" "${formula}"
+    else
+      brew install "${formula}" 2>/dev/null || true
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Phase 4: Clone Dotfiles
+# ---------------------------------------------------------------------------
+
+clone_dotfiles() {
+  bootstrap_echo "Phase 4: Clone dotfiles"
+
+  if [[ -d "${DOTFILES_DIR}" ]]; then
+    bootstrap_info "Dotfiles directory already exists at %s" "${DOTFILES_DIR}"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would pull latest changes"
+    else
+      bootstrap_info "Pulling latest changes..."
+      git -C "${DOTFILES_DIR}" pull --ff-only || bootstrap_warn "Could not fast-forward; continuing with existing checkout"
+    fi
+  else
+    run_cmd "git clone -b '${DOTFILES_BRANCH}' '${DOTFILES_REPO}' '${DOTFILES_DIR}'" \
+      "Clone dotfiles repo"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 5: Run setup.sh
+# ---------------------------------------------------------------------------
+
+run_setup_sh() {
+  bootstrap_echo "Phase 5: Run setup.sh"
+
+  local setup_cmd="bash '${DOTFILES_DIR}/setup.sh'"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    setup_cmd="${setup_cmd} --dry-run"
+  fi
+
+  run_cmd "${setup_cmd}" "Run dotfiles setup (stow symlinks, hostname, directories, tmux)"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 6: asdf + Language Runtimes
+# ---------------------------------------------------------------------------
+
+add_or_update_asdf_plugin() {
+  local name="$1"
+  local url="$2"
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_info "[DRY RUN] Would add/update asdf plugin: %s" "${name}"
+    return
+  fi
+
+  if ! asdf plugin list 2>/dev/null | grep -Fq "${name}"; then
+    asdf plugin add "${name}" "${url}"
+  else
+    asdf plugin update "${name}"
+  fi
+}
+
+install_asdf_language() {
+  local language="$1"
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_info "[DRY RUN] Would install asdf language: %s" "${language}"
+    return
+  fi
+
+  local versions
+  # Read versions for this language from .tool-versions
+  versions="$(grep "^${language} " "${HOME}/.tool-versions" | sed "s/^${language} //")"
+
+  if [[ -z "${versions}" ]]; then
+    bootstrap_warn "No version found for %s in .tool-versions" "${language}"
+    return
+  fi
+
+  for version in ${versions}; do
+    if asdf list "${language}" 2>/dev/null | grep -Fq "${version}"; then
+      bootstrap_info "%s %s already installed" "${language}" "${version}"
+    else
+      bootstrap_info "Installing %s %s ..." "${language}" "${version}"
+      asdf install "${language}" "${version}"
+    fi
+  done
+}
+
+install_asdf_languages() {
+  bootstrap_echo "Phase 6: asdf + language runtimes"
+
+  if [[ "${DRY_RUN}" == "false" ]]; then
+    brew install asdf 2>/dev/null || true
+    # shellcheck source=/dev/null
+    source "$(brew --prefix asdf)/libexec/asdf.sh" 2>/dev/null || true
+  else
+    bootstrap_info "[DRY RUN] Would install asdf via Homebrew"
+  fi
+
+  add_or_update_asdf_plugin "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
+  add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
+  add_or_update_asdf_plugin "python" "https://github.com/asdf-community/asdf-python.git"
+  add_or_update_asdf_plugin "lua" "https://github.com/Stratus3D/asdf-lua.git"
+
+  install_asdf_language "ruby"
+  install_asdf_language "nodejs"
+  install_asdf_language "python"
+
+  # luarocks 3.13+ has rockspec syntax incompatible with Lua 5.1's parser
+  ASDF_LUA_LUAROCKS_VERSION="3.11.1" install_asdf_language "lua"
+
+  # Configure bundler parallelism
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_info "[DRY RUN] Would configure bundler jobs"
+  else
+    local num_cpus
+    num_cpus="$(sysctl -n hw.ncpu)"
+    bundle config --global jobs "$((num_cpus - 1))" 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 7: Gems + npm Packages
+# ---------------------------------------------------------------------------
+
+gem_install_or_update() {
+  local gem_name="$1"
+
+  if gem list "${gem_name}" --installed >/dev/null 2>&1; then
+    bootstrap_info "Updating gem: %s" "${gem_name}"
+    gem update "${gem_name}" --no-document || true
+  else
+    bootstrap_info "Installing gem: %s" "${gem_name}"
+    gem install "${gem_name}" --no-document || true
+  fi
+}
+
+install_gems_and_npm() {
+  bootstrap_echo "Phase 7: Gems + npm packages"
+
+  # Install gems from ~/.default-gems
+  if [[ -f "${HOME}/.default-gems" ]]; then
+    bootstrap_info "Installing gems from ~/.default-gems ..."
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would install gems: %s" "$(tr '\n' ' ' <"${HOME}/.default-gems")"
+    else
+      while IFS= read -r gem_name; do
+        [[ -z "${gem_name}" ]] && continue
+        gem_install_or_update "${gem_name}"
+      done <"${HOME}/.default-gems"
+    fi
+  else
+    bootstrap_warn "%s/.default-gems not found — skipping gem installation" "${HOME}"
+  fi
+
+  # Install npm packages from ~/.default-npm-packages
+  if [[ -f "${HOME}/.default-npm-packages" ]]; then
+    bootstrap_info "Installing npm packages from ~/.default-npm-packages ..."
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would install npm packages: %s" "$(tr '\n' ' ' <"${HOME}/.default-npm-packages")"
+    else
+      while IFS= read -r pkg_name; do
+        [[ -z "${pkg_name}" ]] && continue
+        bootstrap_info "Installing npm package: %s" "${pkg_name}"
+        npm install -g "${pkg_name}" || bootstrap_warn "Failed to install npm package: %s" "${pkg_name}"
+      done <"${HOME}/.default-npm-packages"
+    fi
+  else
+    bootstrap_warn "%s/.default-npm-packages not found — skipping npm installation" "${HOME}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 9: Zsh + Zap (after brew bundle so eza, starship, zsh-abbr, zoxide are available)
+# ---------------------------------------------------------------------------
+
+setup_zsh() {
+  bootstrap_echo "Phase 9: Zsh + Zap"
+
+  local brew_zsh="${HOMEBREW_PREFIX}/bin/zsh"
+
+  # Add Homebrew zsh to /etc/shells if missing
+  if ! grep -Fq "${brew_zsh}" /etc/shells 2>/dev/null; then
+    run_cmd "echo '${brew_zsh}' | sudo tee -a /etc/shells" \
+      "Add Homebrew Zsh to /etc/shells"
+  else
+    bootstrap_info "Homebrew Zsh already in /etc/shells"
+  fi
+
+  # Set as default shell
+  if [[ "${SHELL}" != "${brew_zsh}" ]]; then
+    run_cmd "chsh -s '${brew_zsh}'" "Set Homebrew Zsh as default shell"
+  else
+    bootstrap_info "Homebrew Zsh already the default shell"
+  fi
+
+  # Install Zap plugin manager
+  if [[ -d "${HOME}/.local/share/zap" ]]; then
+    bootstrap_info "Zap already installed"
+  else
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would install Zap (Zsh plugin manager) with --keep flag"
+    else
+      bootstrap_info "Installing Zap (Zsh plugin manager)..."
+      zsh <(curl -fsSL https://raw.githubusercontent.com/zap-zsh/zap/master/install.zsh) --branch release-v1 --keep
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 8: brew bundle install
+# ---------------------------------------------------------------------------
+
+run_brew_bundle() {
+  bootstrap_echo "Phase 8: brew bundle install"
+
+  if [[ "${SKIP_BREW_BUNDLE}" == "true" ]]; then
+    bootstrap_info "Skipping brew bundle install (--skip-brew-bundle)"
+    return
+  fi
+
+  if [[ ! -f "${HOME}/Brewfile" ]]; then
+    bootstrap_warn "%s/Brewfile not found — skipping brew bundle" "${HOME}"
+    return
+  fi
+
+  run_cmd "brew bundle install --file='${HOME}/Brewfile'" \
+    "Install packages from Brewfile (this may take a while)"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 10: Summary
+# ---------------------------------------------------------------------------
+
+show_summary() {
+  bootstrap_echo "Phase 10: Bootstrap complete!"
+
+  cat <<'EOF'
+
+Remaining manual steps:
+  -> Launch nvim and run :checkhealth
+  -> Create ~/.gitconfig.local with your name and email
+  -> Install Tmux plugins: start tmux, then press <prefix> + I
+  -> Restart your terminal to pick up all changes
+
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  parse_args "$@"
+  preflight
+
+  install_xcode_cli_tools
+  install_rosetta
+  install_homebrew
+  clone_dotfiles
+  run_setup_sh
+  install_asdf_languages
+  install_gems_and_npm
+  run_brew_bundle
+  setup_zsh
+  show_summary
+}
+
+trap 'bootstrap_error "Script failed at line %s" "$LINENO"' ERR
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `scripts/bootstrap.sh` — a single, curl-runnable script that sets up a fresh Mac from zero
- Replace the multi-step New Mac Bootstrap workflow (Laptop script + manual clone + manual brew bundle) with one command
- Update README.md, CLAUDE.md, and installation guide to reference the new bootstrap command

### What the bootstrap script does (11 phases)

0. **Preflight** — verify macOS, detect architecture, parse flags (`--dry-run`, `--skip-brew-bundle`)
1. **Xcode CLI Tools** — install if missing, wait for GUI installer
2. **Rosetta 2** — install on Apple Silicon if needed
3. **Homebrew + minimal formulae** — git, stow, coreutils, openssl@3, libyaml, readline, zsh
4. **Clone dotfiles** — `git clone` to `~/dotfiles` (or `pull --ff-only` if exists)
5. **Run `setup.sh`** — existing stow symlinks, hostname, directories, tmux setup
6. **asdf + language runtimes** — Ruby, Node.js, Python, Lua from `.tool-versions`
7. **Gems + npm packages** — from `~/.default-gems` / `~/.default-npm-packages`
8. **Zsh + Zap** — add to `/etc/shells`, set as default, install Zap with `--keep`
9. **`brew bundle install`** — full Brewfile (skippable via `--skip-brew-bundle`)
10. **Summary** — print remaining manual steps

### Usage

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/pyeh/dotfiles/master/scripts/bootstrap.sh)
```

## Test plan

- [x] `shellcheck scripts/bootstrap.sh` passes clean
- [x] `./scripts/lint-shell` passes clean for bootstrap.sh
- [x] `./scripts/bootstrap.sh --help` shows usage
- [x] `./scripts/bootstrap.sh --dry-run` walks all 11 phases with informative output
- [x] Run on a fresh Mac (or re-run on existing machine) to verify idempotency