### PR TITLE
chore: add claude config, ignore vendored skills, harden setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,16 +23,43 @@ scratchpads/
 *.rej
 
 # Claude Code runtime files (machine-specific, not config)
+claude/.claude/backups/
+claude/.claude/cache/
 claude/.claude/debug/
 claude/.claude/file-history/
 claude/.claude/history.jsonl
-claude/.claude/plugins/
+claude/.claude/mcp-needs-auth-cache.json
+claude/.claude/paste-cache/
+claude/.claude/plans/
 claude/.claude/projects/
+claude/.claude/session-env/
+claude/.claude/sessions/
 claude/.claude/settings.local.json
 claude/.claude/shell-snapshots/
 claude/.claude/stats-cache.json
 claude/.claude/statsig/
+claude/.claude/tasks/
+claude/.claude/teams/
+claude/.claude/telemetry/
 claude/.claude/todos/
+
+# Claude plugins: keep manifests, ignore downloaded plugin bodies
+claude/.claude/plugins/*
+!claude/.claude/plugins/installed_plugins.json
+!claude/.claude/plugins/known_marketplaces.json
+
+# Claude skills: ignore externally-managed skills, keep only user-authored
+# To add a personal skill, whitelist it explicitly (see commands/ example below).
+claude/.claude/skills/*
+!claude/.claude/skills/commands/
+!claude/.claude/skills/commands/**
+
+# Never vendor skill release artifacts, CI metadata, or nested repos
+claude/.claude/skills/**/*.zip
+claude/.claude/skills/**/*.tar.gz
+claude/.claude/skills/**/.github/
+claude/.claude/skills/**/.git/
+claude/.claude/skills/**/node_modules/
 
 # Backup files
 *.bak

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
-        exclude: ^(scratchpads/|\.github/|.*plugins/)
+        exclude: ^(scratchpads/|\.github/|.*plugins/|claude/\.claude/skills/)
 
   # YAML validation
   - repo: https://github.com/adrienverge/yamllint

--- a/claude/.claude/plugins/installed_plugins.json
+++ b/claude/.claude/plugins/installed_plugins.json
@@ -1,0 +1,57 @@
+{
+  "version": 2,
+  "plugins": {
+    "document-skills@anthropic-agent-skills": [
+      {
+        "scope": "project",
+        "projectPath": "/Users/pyeh",
+        "installPath": "/Users/pyeh/.claude/plugins/cache/anthropic-agent-skills/document-skills/unknown",
+        "version": "unknown",
+        "installedAt": "2025-10-24T04:31:24.955Z",
+        "lastUpdated": "2025-12-11T05:47:20.559Z",
+        "gitCommitSha": "c74d647e56e6daa12029b6acb11a821348ad044b"
+      }
+    ],
+    "example-skills@anthropic-agent-skills": [
+      {
+        "scope": "project",
+        "projectPath": "/Users/pyeh",
+        "installPath": "/Users/pyeh/.claude/plugins/cache/anthropic-agent-skills/example-skills/unknown",
+        "version": "unknown",
+        "installedAt": "2025-10-24T04:31:24.955Z",
+        "lastUpdated": "2025-12-11T05:47:20.559Z",
+        "gitCommitSha": "c74d647e56e6daa12029b6acb11a821348ad044b"
+      }
+    ],
+    "everything-claude-code@everything-claude-code": [
+      {
+        "scope": "user",
+        "installPath": "/Users/pyeh/.claude/plugins/cache/everything-claude-code/everything-claude-code/1.4.1",
+        "version": "1.4.1",
+        "installedAt": "2026-02-25T06:30:10.742Z",
+        "lastUpdated": "2026-02-25T06:30:10.742Z",
+        "gitCommitSha": "3d63fd33b9e3343bbc466a21e5df97032cc43ec5"
+      }
+    ],
+    "andrej-karpathy-skills@karpathy-skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/pyeh/.claude/plugins/cache/karpathy-skills/andrej-karpathy-skills/1.0.0",
+        "version": "1.0.0",
+        "installedAt": "2026-04-17T22:24:45.723Z",
+        "lastUpdated": "2026-04-17T22:24:45.723Z",
+        "gitCommitSha": "c9a44ae835fa2f5765a697216692705761a53f40"
+      }
+    ],
+    "last30days@last30days-skill": [
+      {
+        "scope": "user",
+        "installPath": "/Users/pyeh/.claude/plugins/cache/last30days-skill/last30days/3.0.5",
+        "version": "3.0.5",
+        "installedAt": "2026-04-17T22:32:13.118Z",
+        "lastUpdated": "2026-04-17T22:32:13.118Z",
+        "gitCommitSha": "371f62a403d075550e9d5ce3035f1314053ea109"
+      }
+    ]
+  }
+}

--- a/claude/.claude/plugins/known_marketplaces.json
+++ b/claude/.claude/plugins/known_marketplaces.json
@@ -1,0 +1,42 @@
+{
+  "anthropic-agent-skills": {
+    "source": {
+      "source": "github",
+      "repo": "anthropics/skills"
+    },
+    "installLocation": "/Users/pyeh/.claude/plugins/marketplaces/anthropic-agent-skills",
+    "lastUpdated": "2025-10-24T05:13:01.966Z"
+  },
+  "claude-plugins-official": {
+    "source": {
+      "source": "github",
+      "repo": "anthropics/claude-plugins-official"
+    },
+    "installLocation": "/Users/pyeh/.claude/plugins/marketplaces/claude-plugins-official",
+    "lastUpdated": "2026-04-17T22:38:39.402Z"
+  },
+  "everything-claude-code": {
+    "source": {
+      "source": "github",
+      "repo": "affaan-m/everything-claude-code"
+    },
+    "installLocation": "/Users/pyeh/.claude/plugins/marketplaces/everything-claude-code",
+    "lastUpdated": "2026-02-25T06:29:42.151Z"
+  },
+  "karpathy-skills": {
+    "source": {
+      "source": "github",
+      "repo": "forrestchang/andrej-karpathy-skills"
+    },
+    "installLocation": "/Users/pyeh/.claude/plugins/marketplaces/karpathy-skills",
+    "lastUpdated": "2026-04-17T22:24:13.410Z"
+  },
+  "last30days-skill": {
+    "source": {
+      "source": "github",
+      "repo": "mvanhorn/last30days-skill"
+    },
+    "installLocation": "/Users/pyeh/.claude/plugins/marketplaces/last30days-skill",
+    "lastUpdated": "2026-04-17T22:27:22.165Z"
+  }
+}

--- a/claude/.claude/rules/common/agents.md
+++ b/claude/.claude/rules/common/agents.md
@@ -1,0 +1,49 @@
+# Agent Orchestration
+
+## Available Agents
+
+Located in `~/.claude/agents/`:
+
+| Agent | Purpose | When to Use |
+|-------|---------|-------------|
+| planner | Implementation planning | Complex features, refactoring |
+| architect | System design | Architectural decisions |
+| tdd-guide | Test-driven development | New features, bug fixes |
+| code-reviewer | Code review | After writing code |
+| security-reviewer | Security analysis | Before commits |
+| build-error-resolver | Fix build errors | When build fails |
+| e2e-runner | E2E testing | Critical user flows |
+| refactor-cleaner | Dead code cleanup | Code maintenance |
+| doc-updater | Documentation | Updating docs |
+
+## Immediate Agent Usage
+
+No user prompt needed:
+1. Complex feature requests - Use **planner** agent
+2. Code just written/modified - Use **code-reviewer** agent
+3. Bug fix or new feature - Use **tdd-guide** agent
+4. Architectural decision - Use **architect** agent
+
+## Parallel Task Execution
+
+ALWAYS use parallel Task execution for independent operations:
+
+```markdown
+# GOOD: Parallel execution
+Launch 3 agents in parallel:
+1. Agent 1: Security analysis of auth module
+2. Agent 2: Performance review of cache system
+3. Agent 3: Type checking of utilities
+
+# BAD: Sequential when unnecessary
+First agent 1, then agent 2, then agent 3
+```
+
+## Multi-Perspective Analysis
+
+For complex problems, use split role sub-agents:
+- Factual reviewer
+- Senior engineer
+- Security expert
+- Consistency reviewer
+- Redundancy checker

--- a/claude/.claude/rules/common/coding-style.md
+++ b/claude/.claude/rules/common/coding-style.md
@@ -1,0 +1,48 @@
+# Coding Style
+
+## Immutability (CRITICAL)
+
+ALWAYS create new objects, NEVER mutate existing ones:
+
+```
+// Pseudocode
+WRONG:  modify(original, field, value) → changes original in-place
+CORRECT: update(original, field, value) → returns new copy with change
+```
+
+Rationale: Immutable data prevents hidden side effects, makes debugging easier, and enables safe concurrency.
+
+## File Organization
+
+MANY SMALL FILES > FEW LARGE FILES:
+- High cohesion, low coupling
+- 200-400 lines typical, 800 max
+- Extract utilities from large modules
+- Organize by feature/domain, not by type
+
+## Error Handling
+
+ALWAYS handle errors comprehensively:
+- Handle errors explicitly at every level
+- Provide user-friendly error messages in UI-facing code
+- Log detailed error context on the server side
+- Never silently swallow errors
+
+## Input Validation
+
+ALWAYS validate at system boundaries:
+- Validate all user input before processing
+- Use schema-based validation where available
+- Fail fast with clear error messages
+- Never trust external data (API responses, user input, file content)
+
+## Code Quality Checklist
+
+Before marking work complete:
+- [ ] Code is readable and well-named
+- [ ] Functions are small (<50 lines)
+- [ ] Files are focused (<800 lines)
+- [ ] No deep nesting (>4 levels)
+- [ ] Proper error handling
+- [ ] No hardcoded values (use constants or config)
+- [ ] No mutation (immutable patterns used)

--- a/claude/.claude/rules/common/development-workflow.md
+++ b/claude/.claude/rules/common/development-workflow.md
@@ -1,0 +1,29 @@
+# Development Workflow
+
+> This file extends [common/git-workflow.md](./git-workflow.md) with the full feature development process that happens before git operations.
+
+The Feature Implementation Workflow describes the development pipeline: planning, TDD, code review, and then committing to git.
+
+## Feature Implementation Workflow
+
+1. **Plan First**
+   - Use **planner** agent to create implementation plan
+   - Identify dependencies and risks
+   - Break down into phases
+
+2. **TDD Approach**
+   - Use **tdd-guide** agent
+   - Write tests first (RED)
+   - Implement to pass tests (GREEN)
+   - Refactor (IMPROVE)
+   - Verify 80%+ coverage
+
+3. **Code Review**
+   - Use **code-reviewer** agent immediately after writing code
+   - Address CRITICAL and HIGH issues
+   - Fix MEDIUM issues when possible
+
+4. **Commit & Push**
+   - Detailed commit messages
+   - Follow conventional commits format
+   - See [git-workflow.md](./git-workflow.md) for commit message format and PR process

--- a/claude/.claude/rules/common/git-workflow.md
+++ b/claude/.claude/rules/common/git-workflow.md
@@ -1,0 +1,24 @@
+# Git Workflow
+
+## Commit Message Format
+```
+<type>: <description>
+
+<optional body>
+```
+
+Types: feat, fix, refactor, docs, test, chore, perf, ci
+
+Note: Attribution disabled globally via ~/.claude/settings.json.
+
+## Pull Request Workflow
+
+When creating PRs:
+1. Analyze full commit history (not just latest commit)
+2. Use `git diff [base-branch]...HEAD` to see all changes
+3. Draft comprehensive PR summary
+4. Include test plan with TODOs
+5. Push with `-u` flag if new branch
+
+> For the full development process (planning, TDD, code review) before git operations,
+> see [development-workflow.md](./development-workflow.md).

--- a/claude/.claude/rules/common/hooks.md
+++ b/claude/.claude/rules/common/hooks.md
@@ -1,0 +1,30 @@
+# Hooks System
+
+## Hook Types
+
+- **PreToolUse**: Before tool execution (validation, parameter modification)
+- **PostToolUse**: After tool execution (auto-format, checks)
+- **Stop**: When session ends (final verification)
+
+## Auto-Accept Permissions
+
+Use with caution:
+- Enable for trusted, well-defined plans
+- Disable for exploratory work
+- Never use dangerously-skip-permissions flag
+- Configure `allowedTools` in `~/.claude.json` instead
+
+## TodoWrite Best Practices
+
+Use TodoWrite tool to:
+- Track progress on multi-step tasks
+- Verify understanding of instructions
+- Enable real-time steering
+- Show granular implementation steps
+
+Todo list reveals:
+- Out of order steps
+- Missing items
+- Extra unnecessary items
+- Wrong granularity
+- Misinterpreted requirements

--- a/claude/.claude/rules/common/patterns.md
+++ b/claude/.claude/rules/common/patterns.md
@@ -1,0 +1,31 @@
+# Common Patterns
+
+## Skeleton Projects
+
+When implementing new functionality:
+1. Search for battle-tested skeleton projects
+2. Use parallel agents to evaluate options:
+   - Security assessment
+   - Extensibility analysis
+   - Relevance scoring
+   - Implementation planning
+3. Clone best match as foundation
+4. Iterate within proven structure
+
+## Design Patterns
+
+### Repository Pattern
+
+Encapsulate data access behind a consistent interface:
+- Define standard operations: findAll, findById, create, update, delete
+- Concrete implementations handle storage details (database, API, file, etc.)
+- Business logic depends on the abstract interface, not the storage mechanism
+- Enables easy swapping of data sources and simplifies testing with mocks
+
+### API Response Format
+
+Use a consistent envelope for all API responses:
+- Include a success/status indicator
+- Include the data payload (nullable on error)
+- Include an error message field (nullable on success)
+- Include metadata for paginated responses (total, page, limit)

--- a/claude/.claude/rules/common/performance.md
+++ b/claude/.claude/rules/common/performance.md
@@ -1,0 +1,55 @@
+# Performance Optimization
+
+## Model Selection Strategy
+
+**Haiku 4.5** (90% of Sonnet capability, 3x cost savings):
+- Lightweight agents with frequent invocation
+- Pair programming and code generation
+- Worker agents in multi-agent systems
+
+**Sonnet 4.6** (Best coding model):
+- Main development work
+- Orchestrating multi-agent workflows
+- Complex coding tasks
+
+**Opus 4.5** (Deepest reasoning):
+- Complex architectural decisions
+- Maximum reasoning requirements
+- Research and analysis tasks
+
+## Context Window Management
+
+Avoid last 20% of context window for:
+- Large-scale refactoring
+- Feature implementation spanning multiple files
+- Debugging complex interactions
+
+Lower context sensitivity tasks:
+- Single-file edits
+- Independent utility creation
+- Documentation updates
+- Simple bug fixes
+
+## Extended Thinking + Plan Mode
+
+Extended thinking is enabled by default, reserving up to 31,999 tokens for internal reasoning.
+
+Control extended thinking via:
+- **Toggle**: Option+T (macOS) / Alt+T (Windows/Linux)
+- **Config**: Set `alwaysThinkingEnabled` in `~/.claude/settings.json`
+- **Budget cap**: `export MAX_THINKING_TOKENS=10000`
+- **Verbose mode**: Ctrl+O to see thinking output
+
+For complex tasks requiring deep reasoning:
+1. Ensure extended thinking is enabled (on by default)
+2. Enable **Plan Mode** for structured approach
+3. Use multiple critique rounds for thorough analysis
+4. Use split role sub-agents for diverse perspectives
+
+## Build Troubleshooting
+
+If build fails:
+1. Use **build-error-resolver** agent
+2. Analyze error messages
+3. Fix incrementally
+4. Verify after each fix

--- a/claude/.claude/rules/common/security.md
+++ b/claude/.claude/rules/common/security.md
@@ -1,0 +1,29 @@
+# Security Guidelines
+
+## Mandatory Security Checks
+
+Before ANY commit:
+- [ ] No hardcoded secrets (API keys, passwords, tokens)
+- [ ] All user inputs validated
+- [ ] SQL injection prevention (parameterized queries)
+- [ ] XSS prevention (sanitized HTML)
+- [ ] CSRF protection enabled
+- [ ] Authentication/authorization verified
+- [ ] Rate limiting on all endpoints
+- [ ] Error messages don't leak sensitive data
+
+## Secret Management
+
+- NEVER hardcode secrets in source code
+- ALWAYS use environment variables or a secret manager
+- Validate that required secrets are present at startup
+- Rotate any secrets that may have been exposed
+
+## Security Response Protocol
+
+If security issue found:
+1. STOP immediately
+2. Use **security-reviewer** agent
+3. Fix CRITICAL issues before continuing
+4. Rotate any exposed secrets
+5. Review entire codebase for similar issues

--- a/claude/.claude/rules/common/testing.md
+++ b/claude/.claude/rules/common/testing.md
@@ -1,0 +1,29 @@
+# Testing Requirements
+
+## Minimum Test Coverage: 80%
+
+Test Types (ALL required):
+1. **Unit Tests** - Individual functions, utilities, components
+2. **Integration Tests** - API endpoints, database operations
+3. **E2E Tests** - Critical user flows (framework chosen per language)
+
+## Test-Driven Development
+
+MANDATORY workflow:
+1. Write test first (RED)
+2. Run test - it should FAIL
+3. Write minimal implementation (GREEN)
+4. Run test - it should PASS
+5. Refactor (IMPROVE)
+6. Verify coverage (80%+)
+
+## Troubleshooting Test Failures
+
+1. Use **tdd-guide** agent
+2. Check test isolation
+3. Verify mocks are correct
+4. Fix implementation, not tests (unless tests are wrong)
+
+## Agent Support
+
+- **tdd-guide** - Use PROACTIVELY for new features, enforces write-tests-first

--- a/claude/.claude/rules/golang/coding-style.md
+++ b/claude/.claude/rules/golang/coding-style.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "**/*.go"
+  - "**/go.mod"
+  - "**/go.sum"
+---
+# Go Coding Style
+
+> This file extends [common/coding-style.md](../common/coding-style.md) with Go specific content.
+
+## Formatting
+
+- **gofmt** and **goimports** are mandatory — no style debates
+
+## Design Principles
+
+- Accept interfaces, return structs
+- Keep interfaces small (1-3 methods)
+
+## Error Handling
+
+Always wrap errors with context:
+
+```go
+if err != nil {
+    return fmt.Errorf("failed to create user: %w", err)
+}
+```
+
+## Reference
+
+See skill: `golang-patterns` for comprehensive Go idioms and patterns.

--- a/claude/.claude/rules/golang/hooks.md
+++ b/claude/.claude/rules/golang/hooks.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "**/*.go"
+  - "**/go.mod"
+  - "**/go.sum"
+---
+# Go Hooks
+
+> This file extends [common/hooks.md](../common/hooks.md) with Go specific content.
+
+## PostToolUse Hooks
+
+Configure in `~/.claude/settings.json`:
+
+- **gofmt/goimports**: Auto-format `.go` files after edit
+- **go vet**: Run static analysis after editing `.go` files
+- **staticcheck**: Run extended static checks on modified packages

--- a/claude/.claude/rules/golang/patterns.md
+++ b/claude/.claude/rules/golang/patterns.md
@@ -1,0 +1,45 @@
+---
+paths:
+  - "**/*.go"
+  - "**/go.mod"
+  - "**/go.sum"
+---
+# Go Patterns
+
+> This file extends [common/patterns.md](../common/patterns.md) with Go specific content.
+
+## Functional Options
+
+```go
+type Option func(*Server)
+
+func WithPort(port int) Option {
+    return func(s *Server) { s.port = port }
+}
+
+func NewServer(opts ...Option) *Server {
+    s := &Server{port: 8080}
+    for _, opt := range opts {
+        opt(s)
+    }
+    return s
+}
+```
+
+## Small Interfaces
+
+Define interfaces where they are used, not where they are implemented.
+
+## Dependency Injection
+
+Use constructor functions to inject dependencies:
+
+```go
+func NewUserService(repo UserRepository, logger Logger) *UserService {
+    return &UserService{repo: repo, logger: logger}
+}
+```
+
+## Reference
+
+See skill: `golang-patterns` for comprehensive Go patterns including concurrency, error handling, and package organization.

--- a/claude/.claude/rules/golang/security.md
+++ b/claude/.claude/rules/golang/security.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "**/*.go"
+  - "**/go.mod"
+  - "**/go.sum"
+---
+# Go Security
+
+> This file extends [common/security.md](../common/security.md) with Go specific content.
+
+## Secret Management
+
+```go
+apiKey := os.Getenv("OPENAI_API_KEY")
+if apiKey == "" {
+    log.Fatal("OPENAI_API_KEY not configured")
+}
+```
+
+## Security Scanning
+
+- Use **gosec** for static security analysis:
+  ```bash
+  gosec ./...
+  ```
+
+## Context & Timeouts
+
+Always use `context.Context` for timeout control:
+
+```go
+ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+defer cancel()
+```

--- a/claude/.claude/rules/golang/testing.md
+++ b/claude/.claude/rules/golang/testing.md
@@ -1,0 +1,31 @@
+---
+paths:
+  - "**/*.go"
+  - "**/go.mod"
+  - "**/go.sum"
+---
+# Go Testing
+
+> This file extends [common/testing.md](../common/testing.md) with Go specific content.
+
+## Framework
+
+Use the standard `go test` with **table-driven tests**.
+
+## Race Detection
+
+Always run with the `-race` flag:
+
+```bash
+go test -race ./...
+```
+
+## Coverage
+
+```bash
+go test -cover ./...
+```
+
+## Reference
+
+See skill: `golang-testing` for detailed Go testing patterns and helpers.

--- a/claude/.claude/rules/python/coding-style.md
+++ b/claude/.claude/rules/python/coding-style.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.pyi"
+---
+# Python Coding Style
+
+> This file extends [common/coding-style.md](../common/coding-style.md) with Python specific content.
+
+## Standards
+
+- Follow **PEP 8** conventions
+- Use **type annotations** on all function signatures
+
+## Immutability
+
+Prefer immutable data structures:
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class User:
+    name: str
+    email: str
+
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x: float
+    y: float
+```
+
+## Formatting
+
+- **black** for code formatting
+- **isort** for import sorting
+- **ruff** for linting
+
+## Reference
+
+See skill: `python-patterns` for comprehensive Python idioms and patterns.

--- a/claude/.claude/rules/python/hooks.md
+++ b/claude/.claude/rules/python/hooks.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.pyi"
+---
+# Python Hooks
+
+> This file extends [common/hooks.md](../common/hooks.md) with Python specific content.
+
+## PostToolUse Hooks
+
+Configure in `~/.claude/settings.json`:
+
+- **black/ruff**: Auto-format `.py` files after edit
+- **mypy/pyright**: Run type checking after editing `.py` files
+
+## Warnings
+
+- Warn about `print()` statements in edited files (use `logging` module instead)

--- a/claude/.claude/rules/python/patterns.md
+++ b/claude/.claude/rules/python/patterns.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.pyi"
+---
+# Python Patterns
+
+> This file extends [common/patterns.md](../common/patterns.md) with Python specific content.
+
+## Protocol (Duck Typing)
+
+```python
+from typing import Protocol
+
+class Repository(Protocol):
+    def find_by_id(self, id: str) -> dict | None: ...
+    def save(self, entity: dict) -> dict: ...
+```
+
+## Dataclasses as DTOs
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class CreateUserRequest:
+    name: str
+    email: str
+    age: int | None = None
+```
+
+## Context Managers & Generators
+
+- Use context managers (`with` statement) for resource management
+- Use generators for lazy evaluation and memory-efficient iteration
+
+## Reference
+
+See skill: `python-patterns` for comprehensive patterns including decorators, concurrency, and package organization.

--- a/claude/.claude/rules/python/security.md
+++ b/claude/.claude/rules/python/security.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.pyi"
+---
+# Python Security
+
+> This file extends [common/security.md](../common/security.md) with Python specific content.
+
+## Secret Management
+
+```python
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+api_key = os.environ["OPENAI_API_KEY"]  # Raises KeyError if missing
+```
+
+## Security Scanning
+
+- Use **bandit** for static security analysis:
+  ```bash
+  bandit -r src/
+  ```
+
+## Reference
+
+See skill: `django-security` for Django-specific security guidelines (if applicable).

--- a/claude/.claude/rules/python/testing.md
+++ b/claude/.claude/rules/python/testing.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.pyi"
+---
+# Python Testing
+
+> This file extends [common/testing.md](../common/testing.md) with Python specific content.
+
+## Framework
+
+Use **pytest** as the testing framework.
+
+## Coverage
+
+```bash
+pytest --cov=src --cov-report=term-missing
+```
+
+## Test Organization
+
+Use `pytest.mark` for test categorization:
+
+```python
+import pytest
+
+@pytest.mark.unit
+def test_calculate_total():
+    ...
+
+@pytest.mark.integration
+def test_database_connection():
+    ...
+```
+
+## Reference
+
+See skill: `python-testing` for detailed pytest patterns and fixtures.

--- a/claude/.claude/rules/typescript/coding-style.md
+++ b/claude/.claude/rules/typescript/coding-style.md
@@ -1,0 +1,65 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+# TypeScript/JavaScript Coding Style
+
+> This file extends [common/coding-style.md](../common/coding-style.md) with TypeScript/JavaScript specific content.
+
+## Immutability
+
+Use spread operator for immutable updates:
+
+```typescript
+// WRONG: Mutation
+function updateUser(user, name) {
+  user.name = name  // MUTATION!
+  return user
+}
+
+// CORRECT: Immutability
+function updateUser(user, name) {
+  return {
+    ...user,
+    name
+  }
+}
+```
+
+## Error Handling
+
+Use async/await with try-catch:
+
+```typescript
+try {
+  const result = await riskyOperation()
+  return result
+} catch (error) {
+  console.error('Operation failed:', error)
+  throw new Error('Detailed user-friendly message')
+}
+```
+
+## Input Validation
+
+Use Zod for schema-based validation:
+
+```typescript
+import { z } from 'zod'
+
+const schema = z.object({
+  email: z.string().email(),
+  age: z.number().int().min(0).max(150)
+})
+
+const validated = schema.parse(input)
+```
+
+## Console.log
+
+- No `console.log` statements in production code
+- Use proper logging libraries instead
+- See hooks for automatic detection

--- a/claude/.claude/rules/typescript/hooks.md
+++ b/claude/.claude/rules/typescript/hooks.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+# TypeScript/JavaScript Hooks
+
+> This file extends [common/hooks.md](../common/hooks.md) with TypeScript/JavaScript specific content.
+
+## PostToolUse Hooks
+
+Configure in `~/.claude/settings.json`:
+
+- **Prettier**: Auto-format JS/TS files after edit
+- **TypeScript check**: Run `tsc` after editing `.ts`/`.tsx` files
+- **console.log warning**: Warn about `console.log` in edited files
+
+## Stop Hooks
+
+- **console.log audit**: Check all modified files for `console.log` before session ends

--- a/claude/.claude/rules/typescript/patterns.md
+++ b/claude/.claude/rules/typescript/patterns.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+# TypeScript/JavaScript Patterns
+
+> This file extends [common/patterns.md](../common/patterns.md) with TypeScript/JavaScript specific content.
+
+## API Response Format
+
+```typescript
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+  meta?: {
+    total: number
+    page: number
+    limit: number
+  }
+}
+```
+
+## Custom Hooks Pattern
+
+```typescript
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(handler)
+  }, [value, delay])
+
+  return debouncedValue
+}
+```
+
+## Repository Pattern
+
+```typescript
+interface Repository<T> {
+  findAll(filters?: Filters): Promise<T[]>
+  findById(id: string): Promise<T | null>
+  create(data: CreateDto): Promise<T>
+  update(id: string, data: UpdateDto): Promise<T>
+  delete(id: string): Promise<void>
+}
+```

--- a/claude/.claude/rules/typescript/security.md
+++ b/claude/.claude/rules/typescript/security.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+# TypeScript/JavaScript Security
+
+> This file extends [common/security.md](../common/security.md) with TypeScript/JavaScript specific content.
+
+## Secret Management
+
+```typescript
+// NEVER: Hardcoded secrets
+const apiKey = "sk-proj-xxxxx"
+
+// ALWAYS: Environment variables
+const apiKey = process.env.OPENAI_API_KEY
+
+if (!apiKey) {
+  throw new Error('OPENAI_API_KEY not configured')
+}
+```
+
+## Agent Support
+
+- Use **security-reviewer** skill for comprehensive security audits

--- a/claude/.claude/rules/typescript/testing.md
+++ b/claude/.claude/rules/typescript/testing.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+---
+# TypeScript/JavaScript Testing
+
+> This file extends [common/testing.md](../common/testing.md) with TypeScript/JavaScript specific content.
+
+## E2E Testing
+
+Use **Playwright** as the E2E testing framework for critical user flows.
+
+## Agent Support
+
+- **e2e-runner** - Playwright E2E testing specialist

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "enabledPlugins": {
+    "document-skills@anthropic-agent-skills": true,
+    "example-skills@anthropic-agent-skills": true,
+    "everything-claude-code@everything-claude-code": true,
+    "andrej-karpathy-skills@karpathy-skills": true,
+    "last30days@last30days-skill": true
+  },
+  "extraKnownMarketplaces": {
+    "karpathy-skills": {
+      "source": {
+        "source": "github",
+        "repo": "forrestchang/andrej-karpathy-skills"
+      }
+    },
+    "last30days-skill": {
+      "source": {
+        "source": "github",
+        "repo": "mvanhorn/last30days-skill"
+      }
+    }
+  }
+}

--- a/claude/.claude/skills/commands/brainstorm.md
+++ b/claude/.claude/skills/commands/brainstorm.md
@@ -1,0 +1,1 @@
+Use your brainstorming skill.

--- a/claude/.claude/skills/commands/execute-plan.md
+++ b/claude/.claude/skills/commands/execute-plan.md
@@ -1,0 +1,1 @@
+Use your Executing-Plans skill.

--- a/claude/.claude/skills/commands/write-plan.md
+++ b/claude/.claude/skills/commands/write-plan.md
@@ -1,0 +1,1 @@
+Use your Writing-Plans skill.

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e # Terminate script if anything exits with a non-zero value
+set -euo pipefail # Fail on error, undefined vars, and broken pipes
 
 ################################################################################
 # setup.sh
@@ -225,7 +225,7 @@ setup_hostname() {
 }
 
 setup_directories() {
-  if [ -z "${DOTFILES}" ]; then
+  if [ -z "${DOTFILES:-}" ]; then
     export DOTFILES="${HOME}/dotfiles"
   fi
 
@@ -236,7 +236,7 @@ setup_directories() {
     exit 1
   fi
 
-  if [ -z "${XDG_CONFIG_HOME}" ]; then
+  if [ -z "${XDG_CONFIG_HOME:-}" ]; then
     dotfiles_echo "Setting up ~/.config directory..."
     if [ ! -d "${HOME}/.config" ]; then
       if [[ "${DRY_RUN}" == "true" ]]; then


### PR DESCRIPTION
## Summary
- Add `claude/.claude/` config tree: `settings.json`, rules (common + golang/python/typescript), plugin manifests, and personal slash commands under `skills/commands/`
- Stop vendoring third-party Claude skills — broaden `.gitignore` to block skill bodies, `.zip` release artifacts, nested `.github/`/`.git/`/`node_modules/`; whitelist `skills/commands/` only
- Harden `setup.sh`: `set -e` → `set -euo pipefail`, guard `${DOTFILES:-}` / `${XDG_CONFIG_HOME:-}` for `-u` safety
- Exclude `claude/.claude/skills/` from pre-commit shellcheck so vendored scripts can't block commits

## Why
An earlier staging pulled in ~129 third-party skill docs (27k+ lines). Those are managed upstream and drift fast — vendoring them bloats the repo and creates sync tax. Only the personal `skills/commands/` and the rules tree need to live here.

## Test plan
- [x] `bash -n setup.sh` — syntax ok under `set -euo pipefail`
- [x] `./setup.sh --dry-run` — 29 stow packages processed, no unbound-var errors
- [ ] `pre-commit run --all-files` on this branch
- [ ] Fresh clone + `./setup.sh` on a clean machine