### PR TITLE
feat: install gstack and Claude Code plugin marketplaces in bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -652,11 +652,131 @@ setup_zsh() {
 }
 
 # ---------------------------------------------------------------------------
-# Phase 10: Summary
+# Phase 10: gstack (Garry Tan's Claude Code skill suite)
+# ---------------------------------------------------------------------------
+
+install_gstack() {
+  bootstrap_echo "Phase 10: gstack"
+
+  local gstack_repo="https://github.com/garrytan/gstack.git"
+  local gstack_dir="${HOME}/.claude/skills/gstack"
+
+  # gstack requires bun v1.0+ — install if missing
+  if command -v bun &>/dev/null || [[ -x "${HOME}/.bun/bin/bun" ]]; then
+    bootstrap_info "bun already installed"
+  else
+    case "${OS}" in
+      macos)
+        if [[ "${DRY_RUN}" == "true" ]]; then
+          bootstrap_info "[DRY RUN] Would install bun via Homebrew"
+        else
+          bootstrap_info "Installing bun (gstack runtime)..."
+          brew install bun 2>/dev/null || bootstrap_warn "brew install bun failed"
+        fi
+        ;;
+      linux)
+        if [[ "${DRY_RUN}" == "true" ]]; then
+          bootstrap_info "[DRY RUN] Would install bun via https://bun.sh/install"
+        else
+          bootstrap_info "Installing bun (gstack runtime)..."
+          curl -fsSL https://bun.sh/install | bash || bootstrap_warn "bun install script failed"
+        fi
+        ;;
+    esac
+  fi
+
+  # Make ~/.bun/bin available for gstack ./setup if bun was just installed there
+  if [[ -d "${HOME}/.bun/bin" ]]; then
+    export PATH="${HOME}/.bun/bin:${PATH}"
+  fi
+
+  # Ensure parent directory exists
+  if [[ "${DRY_RUN}" == "false" ]]; then
+    mkdir -p "${HOME}/.claude/skills"
+  fi
+
+  # Clone or update gstack repo
+  if [[ -d "${gstack_dir}/.git" ]]; then
+    bootstrap_info "gstack already cloned at %s" "${gstack_dir}"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+      bootstrap_info "[DRY RUN] Would update gstack via git pull"
+    else
+      git -C "${gstack_dir}" pull --ff-only || bootstrap_warn "Could not update gstack; continuing"
+    fi
+  else
+    run_cmd "git clone --single-branch --depth 1 '${gstack_repo}' '${gstack_dir}'" \
+      "Clone gstack repo"
+  fi
+
+  # Run gstack's installer
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    bootstrap_info "[DRY RUN] Would run gstack ./setup"
+  elif [[ -x "${gstack_dir}/setup" ]]; then
+    bootstrap_info "Running gstack setup..."
+    (cd "${gstack_dir}" && ./setup) || bootstrap_warn "gstack setup encountered errors"
+  else
+    bootstrap_warn "gstack setup script not found at %s/setup" "${gstack_dir}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 11: Claude Code plugins (marketplaces + skill bundles)
+# ---------------------------------------------------------------------------
+#
+# Each entry is "marketplace-name:github-owner/repo:plugin@marketplace".
+# Mirrors the user-scope plugins recorded in
+# ~/.claude/plugins/installed_plugins.json and known_marketplaces.json.
+
+CLAUDE_PLUGIN_ENTRIES=(
+  "everything-claude-code:affaan-m/everything-claude-code:everything-claude-code@everything-claude-code"
+  "karpathy-skills:forrestchang/andrej-karpathy-skills:andrej-karpathy-skills@karpathy-skills"
+  "last30days-skill:mvanhorn/last30days-skill:last30days@last30days-skill"
+)
+
+install_claude_plugins() {
+  bootstrap_echo "Phase 11: Claude Code plugins"
+
+  if ! command -v claude &>/dev/null; then
+    bootstrap_warn "claude CLI not found on PATH — skipping plugin installation"
+    bootstrap_warn "Install Claude Code first: https://docs.anthropic.com/en/docs/claude-code"
+    return
+  fi
+
+  local existing_markets=""
+  local existing_plugins=""
+  if [[ "${DRY_RUN}" == "false" ]]; then
+    existing_markets="$(claude plugin marketplace list 2>/dev/null || true)"
+    existing_plugins="$(claude plugin list 2>/dev/null || true)"
+  fi
+
+  for entry in "${CLAUDE_PLUGIN_ENTRIES[@]}"; do
+    local market_name="${entry%%:*}"
+    local rest="${entry#*:}"
+    local repo="${rest%%:*}"
+    local plugin_spec="${rest#*:}"
+
+    if grep -Fq "${market_name}" <<<"${existing_markets}"; then
+      bootstrap_info "Marketplace already registered: %s" "${market_name}"
+    else
+      run_cmd "claude plugin marketplace add '${repo}'" \
+        "Register Claude Code marketplace ${market_name}"
+    fi
+
+    if grep -Fq "${plugin_spec}" <<<"${existing_plugins}"; then
+      bootstrap_info "Plugin already installed: %s" "${plugin_spec}"
+    else
+      run_cmd "claude plugin install '${plugin_spec}' --scope user" \
+        "Install Claude Code plugin ${plugin_spec}"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Phase 12: Summary
 # ---------------------------------------------------------------------------
 
 show_summary() {
-  bootstrap_echo "Phase 10: Bootstrap complete!"
+  bootstrap_echo "Phase 12: Bootstrap complete!"
 
   cat <<'EOF'
 
@@ -686,6 +806,8 @@ main() {
   install_gems_and_npm
   install_packages_full
   setup_zsh
+  install_gstack
+  install_claude_plugins
   show_summary
 }
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -671,7 +671,7 @@ install_gstack() {
           bootstrap_info "[DRY RUN] Would install bun via Homebrew"
         else
           bootstrap_info "Installing bun (gstack runtime)..."
-          brew install bun 2>/dev/null || bootstrap_warn "brew install bun failed"
+          brew install bun || bootstrap_warn "brew install bun failed"
         fi
         ;;
       linux)


### PR DESCRIPTION
## Summary

Extends `scripts/bootstrap.sh` so a fresh macOS / Ubuntu / CachyOS machine ends up with the same Claude Code skill suite the user runs day-to-day.

**New phases:**
- **Phase 10 — gstack** (`install_gstack`): installs `bun` (gstack runtime) via `brew install bun` on macOS or `https://bun.sh/install` on Linux, then clones `garrytan/gstack` into `~/.claude/skills/gstack` (`--single-branch --depth 1`) and runs the upstream `./setup`. Idempotent: reuses existing bun, pulls in place if already cloned, prepends `~/.bun/bin` to PATH so a freshly-installed bun is reachable for the gstack installer.
- **Phase 11 — Claude Code plugins** (`install_claude_plugins`): registers three marketplaces and installs their plugins via the `claude plugin` CLI, scoped `user`. Driven by a single `CLAUDE_PLUGIN_ENTRIES` array (`marketplace-name:owner/repo:plugin@marketplace`) so adding a plugin later is one line. Skips gracefully with a warning if the `claude` CLI isn't on PATH.

**Plugins installed:**
- `everything-claude-code@everything-claude-code` (`affaan-m/everything-claude-code`)
- `andrej-karpathy-skills@karpathy-skills` (`forrestchang/andrej-karpathy-skills`)
- `last30days@last30days-skill` (`mvanhorn/last30days-skill`)

Phase 10's previous "Summary" step is renumbered to Phase 12; `main()` calls `install_gstack` + `install_claude_plugins` between `setup_zsh` and `show_summary`.

## Test Coverage

This is a deployment shell script — appropriate verification surface is integration-style (dry-run + syntax + shellcheck), not unit tests.

```
[+] scripts/bootstrap.sh
    │
    ├── install_gstack()
    │   ├── [VERIFIED via --dry-run]    bun-already-present path
    │   ├── [VERIFIED via --dry-run]    macOS / Linux dry-run install paths
    │   ├── [VERIFIED via --dry-run]    gstack-already-cloned path
    │   ├── [GAP]                       fresh-machine real install (would mutate env)
    │   └── [VERIFIED]                  PATH prepend, parsing logic
    │
    └── install_claude_plugins()
        ├── [VERIFIED via --dry-run]    all three marketplace+plugin entries iterate
        ├── [VERIFIED]                  entry-string parsing (4 fields parsed correctly)
        ├── [VERIFIED]                  claude-CLI-missing warning path (manual)
        └── [GAP]                       real `claude plugin install` outcome (network, auth)
```

Verification: `bash -n` + `shellcheck` + `bash --dry-run` all clean.

## Pre-Landing Review

3 informational findings, 0 critical:
- (5/10) `bootstrap.sh:766,775` — `grep -Fq` substring match for idempotency. Current names don't collide.
- (6/10) `bootstrap.sh:738-740` — `claude plugin install` failures propagate via `set -e`, matching script's existing fail-loud philosophy.
- (7/10) `bootstrap.sh:660` — bun detection covers common paths but not npm-global install.

All judgment-call items, none auto-fixed.

## Adversarial Review

Claude inline (codex unavailable). One FIXABLE finding addressed in `87f9cc5`:
- `brew install bun 2>/dev/null` swallowed brew's stderr. Removed redirect so install errors surface.

**PR Quality Score:** 8.5/10

## Plan Completion

No plan file detected.

## TODOS

`todo.md` exists in different format than gstack spec — left untouched.

## Test plan
- [x] `bash -n scripts/bootstrap.sh` — clean
- [x] `shellcheck scripts/bootstrap.sh` — clean
- [x] `bash scripts/bootstrap.sh --dry-run` — both new phases print expected actions
- [ ] On a fresh macOS box: bootstrap from zero and confirm `claude plugin list` shows all three plugins
- [ ] On a fresh Linux box: confirm `~/.bun/bin/bun` install path works and gstack `./setup` runs