### PR TITLE
fix(fish): stop sourcing bash-only fzf-git.sh in config.fish

### DIFF
--- a/docs/fzf-git-integration.md
+++ b/docs/fzf-git-integration.md
@@ -40,7 +40,9 @@ The following abbreviations are available for direct command-line usage:
 
 ## Installation
 
-The fzf-git.sh script is automatically loaded when you start an interactive shell session. The script is located at `bin/fzf-git.sh` and is sourced by both Fish and Zsh configurations.
+The fzf-git.sh script is automatically loaded when you start an interactive shell session. The script is located at `bin/fzf-git.sh` and is sourced by Bash and Zsh.
+
+> **Note**: Upstream fzf-git.sh is bash/zsh-only — it uses bash syntax (`[[ ]]`, `case ... esac`, `eval ... bindkey ...`) that fish cannot parse, so it is **not** sourced from `config.fish`. See the Fish Shell section under [Integration Details](#fish-shell) for the fish workflow.
 
 ## Dependencies
 
@@ -89,16 +91,16 @@ The script respects the following environment variables:
 
 ## Integration Details
 
-### Fish Shell
+### Bash Shell
 
-The script is loaded in `fish/.config/fish/config.fish` during interactive sessions:
+The script is loaded in `bash/.bashrc`:
 
-```fish
+```bash
 # https://github.com/junegunn/fzf-git.sh
 # Load fzf-git.sh for enhanced git operations with fuzzy finding
-if test -f $DOTFILES/bin/fzf-git.sh
-    source $DOTFILES/bin/fzf-git.sh
-end
+if [[ -f "$DOTFILES/bin/fzf-git.sh" ]]; then
+  source "$DOTFILES/bin/fzf-git.sh"
+fi
 ```
 
 ### Zsh Shell
@@ -112,6 +114,10 @@ if [[ -f "$DOTFILES/bin/fzf-git.sh" ]]; then
   source "$DOTFILES/bin/fzf-git.sh"
 fi
 ```
+
+### Fish Shell
+
+Fish does **not** source `fzf-git.sh` directly because the script is written in bash syntax (`[[ ]]`, `case ... esac`, `eval ... bindkey ...`). Sourcing it from `config.fish` raised a startup error and was removed. Fish users who want the same key bindings should install a fish-native fzf integration such as [PatrickF1/fzf.fish](https://github.com/PatrickF1/fzf.fish).
 
 ### Abbreviations
 

--- a/fish/.config/fish/config.fish
+++ b/fish/.config/fish/config.fish
@@ -25,11 +25,8 @@ if status is-interactive
     # https://github.com/ajeetdsouza/zoxide
     zoxide init fish | source
 
-    # https://github.com/junegunn/fzf-git.sh
-    # Load fzf-git.sh for enhanced git operations with fuzzy finding
-    if test -f $DOTFILES/bin/fzf-git.sh
-        source $DOTFILES/bin/fzf-git.sh
-    end
+    # https://github.com/junegunn/fzf-git.sh is bash/zsh-only (uses [[ ]] and
+    # case/esac); it is sourced from .bashrc and .zshrc, not from fish.
 
     # fzf integration
     # https://github.com/junegunn/fzf#using-homebrew-or-linuxbrew


### PR DESCRIPTION
## Summary

- Fish startup raised an error because `config.fish` was sourcing `bin/fzf-git.sh`, which is written in bash (`[[ ]]`, `case ... esac`, `eval ... bindkey ...`) and cannot be parsed by fish:

  ```text
  ~/dotfiles/bin/fzf-git.sh (line 71): "case" builtin not inside of switch block
      case "$1" in
      ^~~^
  from sourcing file ~/dotfiles/bin/fzf-git.sh
          called on line 31 of file ~/.config/fish/config.fish
  source: Error while reading file "/home/pyeh/dotfiles/bin/fzf-git.sh"
  ```

- Removed the `source $DOTFILES/bin/fzf-git.sh` block from `fish/.config/fish/config.fish` and replaced it with a short comment explaining why.
- Bash (`.bashrc`) and Zsh (`.zshrc`) continue to source the script unchanged.
- Updated `docs/fzf-git-integration.md` to reflect the bash/zsh-only scope and point fish users at a fish-native alternative.

## Test plan

- [x] `fish -n fish/.config/fish/config.fish` — syntax check passes
- [x] `fish -ic 'echo ok'` — interactive startup completes with no `case` error
- [ ] `bash -ic 'type __fzf_git_color'` — confirms bash still sources `fzf-git.sh`
- [ ] `zsh -ic 'type __fzf_git_color'` — confirms zsh still sources `fzf-git.sh`
- [ ] Open a fresh fish session, run `gfzfb` — expands to `fzf-git.sh --run branches` (pre-existing fish behaviour, not changed by this PR)
